### PR TITLE
Generate the conda environment.yml from the python-requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,11 @@ ARCH     ?= rv32imc
 SOURCE 	 ?= "."
 
 ## @section Conda
-conda:
-	conda update conda
+conda: environment.yml
 	conda env create -f environment.yml
+
+environment.yml: python-requirements.txt
+	util/python-requirements2conda.sh
 
 ## @section Linux-Emulation
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,0 @@
-name: core-v-mini-mcu
-channels:
-  - defaults
-dependencies:
-  - python=3.8
-

--- a/util/python-requirements2conda.sh
+++ b/util/python-requirements2conda.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+cat <<< 'name: core-v-mini-mcu
+channels:
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - pip:' > environment.yml
+
+lines=`cat python-requirements.txt |sed /^$/d | sed /^#/d`;
+while read -r i
+do
+	echo "    - $i" >> environment.yml ;
+done <<< "$lines"


### PR DESCRIPTION
- created a script to generate the environment.yml for anaconda from the python-requirements.txt
- removed ```conda update conda``` as it might break users python setup for unrelated projects 