### PR TITLE
Use bash instead of sh for ubuntu

### DIFF
--- a/util/python-requirements2conda.sh
+++ b/util/python-requirements2conda.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 cat <<< 'name: core-v-mini-mcu
 channels:
   - defaults


### PR DESCRIPTION
Ubuntu uses dash for /bin/sh which doesn't support the redirect. Use bash instead.