### PR TITLE
Fixed a reset bug.

### DIFF
--- a/hw/fpga/xilinx_core_v_mini_mcu_wrapper.sv
+++ b/hw/fpga/xilinx_core_v_mini_mcu_wrapper.sv
@@ -68,7 +68,7 @@ module xilinx_core_v_mini_mcu_wrapper
   logic [CLK_LED_COUNT_LENGTH - 1:0] clk_count;
 
   // low active reset
-  assign rst_n   = !rst_i;
+  assign rst_n   = rst_i;
 
   // reset LED for debugging
   assign rst_led = rst_n;


### PR DESCRIPTION
The board's pushbutton "CPU RESET", used as the system's reset source, generates a logic zero when pressed (one otherwise), so it is already active low. It does not need to be complemented inside the top-level wrapper.