### PR TITLE
Some updates for CV32E40P usage and GCC 14.0 based toolchain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ make app TARGET=pynq-z2
 Or, if you use the OpenHW Group [GCC](https://www.embecosm.com/resources/tool-chain-downloads/#corev) compiler with CORE_PULP extensions, make sure to point the `RISCV` env variable to the OpenHW Group compiler, then just run:
 
 ```
-make app COMPILER_PREFIX=riscv32-corev- ARCH=rv32imc_zicsr_zifencei_xcvhwlp1p0_xcvmem1p0_xcvmac1p0_xcvbi1p0_xcvalu1p0_xcvsimd1p0_xcvbitmanip1p0
+make app COMPILER_PREFIX=riscv32-corev- ARCH=rv32imc_zicsr_zifencei_xcvhwlp_xcvmem_xcvmac_xcvbi_xcvalu_xcvsimd_xcvbitmanip
 ```
 
 This will create the executable file to be loaded into your target system (ASIC, FPGA, Simulation).

--- a/hw/vendor/openhwgroup_cv32e40p.lock.hjson
+++ b/hw/vendor/openhwgroup_cv32e40p.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/openhwgroup/cv32e40p.git
-    rev: c8d65849ec060c6f7bc62325b46ba0ab7eae8805
+    rev: 370cf19b3b60cbdc847ff102551392dd501029a2
   }
 }

--- a/hw/vendor/openhwgroup_cv32e40p.vendor.hjson
+++ b/hw/vendor/openhwgroup_cv32e40p.vendor.hjson
@@ -7,7 +7,7 @@
 
   upstream: {
     url: "https://github.com/openhwgroup/cv32e40p.git",
-    rev: "c8d65849ec060c6f7bc62325b46ba0ab7eae8805",
+    rev: "370cf19b3b60cbdc847ff102551392dd501029a2",
   },
 
   patch_dir: "patches/openhwgroup_cv32e40p",

--- a/hw/vendor/openhwgroup_cv32e40p/.gitignore
+++ b/hw/vendor/openhwgroup_cv32e40p/.gitignore
@@ -18,3 +18,9 @@ TAGS
 /build
 /Bender.lock
 /Bender.local
+golden_reference_design
+golden.src
+revised.src
+cadence_conformal
+synopsys_formality
+questa_autocheck

--- a/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_instr_trace.svh
+++ b/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_instr_trace.svh
@@ -679,22 +679,22 @@ class instr_trace_t;
       // decode and print instruction
       case (instr[11:8])
         // cv.starti, cv.endi
-        4'b0000, 4'b0010: str = $sformatf("%-16s %d, 0x%0x", mnemonic, rd[0], imm_iz_type);
+        4'b0000, 4'b0010: str = $sformatf("%-16s %d, 0x%0x", mnemonic, instr[7], imm_iz_type);
         // cv.counti
-        4'b0100: str = $sformatf("%-16s %d, %d", mnemonic, rd[0], imm_iz_type);
+        4'b0100: str = $sformatf("%-16s %d, %d", mnemonic, instr[7], imm_iz_type);
         // cv.start, cv.end, cv.count
         4'b0001, 4'b0011, 4'b0101: begin
           regs_read.push_back('{rs1, rs1_value, 0});
-          str = $sformatf("%-16s %d, %s", mnemonic, rd[0], regAddrToStr(rs1));
+          str = $sformatf("%-16s %d, %s", mnemonic, instr[7], regAddrToStr(rs1));
         end
         // cv.setupi
         4'b0110: begin
-          str = $sformatf("%-16s %d, %d, 0x%0x", mnemonic, rd[0], imm_iz_type, rs1);
+          str = $sformatf("%-16s %d, %d, 0x%0x", mnemonic, instr[7], imm_iz_type, rs1);
         end
         // cv.setup
         4'b0111: begin
           regs_read.push_back('{rs1, rs1_value, 0});
-          str = $sformatf("%-16s %d, %s, 0x%0x", mnemonic, rd[0], regAddrToStr(rs1), imm_iz_type);
+          str = $sformatf("%-16s %d, %s, 0x%0x", mnemonic, instr[7], regAddrToStr(rs1), imm_iz_type);
         end
       endcase
     end
@@ -861,7 +861,7 @@ class instr_trace_t;
           endcase
           str_sci  = "";
         end
-  
+
         // shuffle/pack
         6'b110000: begin
           if (instr[14:12] == 3'b111) begin

--- a/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_rvfi.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_rvfi.sv
@@ -73,6 +73,10 @@ module cv32e40p_rvfi
     input logic        is_compressed_id_i,
 
     input logic ebrk_insn_dec_i,
+    input logic ecall_insn_dec_i,
+
+    input logic mret_insn_dec_i,
+    input logic mret_dec_i,
 
     input logic [5:0] csr_cause_i,
 
@@ -125,6 +129,9 @@ module cv32e40p_rvfi
     input logic [31:0] data_addr_ex_i,
     input logic [31:0] data_wdata_ex_i,
     input logic        lsu_split_q_ex_i,
+
+    input logic mult_ready_i,
+    input logic alu_ready_i,
 
     //// WB probes ////
     input logic [31:0] pc_wb_i,
@@ -202,6 +209,7 @@ module cv32e40p_rvfi
     input logic            csr_we_i,
     input logic     [31:0] csr_wdata_int_i,
 
+    input logic    csr_fregs_we_i,
     input logic    csr_jvt_we_i,
     input Status_t csr_mstatus_n_i,
     input Status_t csr_mstatus_q_i,
@@ -617,6 +625,8 @@ module cv32e40p_rvfi
   logic pc_mux_interrupt;
   logic pc_mux_nmi;
 
+  localparam logic [31:0] MSTATUS_WRITE_MASK = 32'h0000_6088;
+
   `include "pipe_freeze_trace.sv"
 
   `include "insn_trace.sv"
@@ -633,6 +643,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   logic   [2:0] saved_debug_cause;
   integer       next_send;
 
+  event         e_empty_queue;
   function void empty_fifo();
     integer i, trace_q_size;
     trace_q_size = wb_bypass_trace_q.size();
@@ -648,6 +659,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           new_rvfi_trace.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
           rvfi_trace_q.push_back(new_rvfi_trace);
           next_send = next_send + 1;
+          ->e_empty_queue;
         end else begin
           wb_bypass_trace_q.push_back(new_rvfi_trace);
         end
@@ -658,6 +670,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   /*
    * Function used to alocate a new insn and send it to the rvfi driver
    */
+  event e_add_to_bypass;
   function void send_rvfi(insn_trace_t m_wb_insn);
     insn_trace_t new_rvfi_trace;
     new_rvfi_trace = new();
@@ -667,6 +680,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       next_send = next_send + 1;
     end else begin
       wb_bypass_trace_q.push_back(new_rvfi_trace);
+      ->e_add_to_bypass;
     end
     empty_fifo();
   endfunction
@@ -837,7 +851,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
     //CSR
     rvfi_csr_mstatus_rmask = new_rvfi_trace.m_csr.mstatus_rmask | new_rvfi_trace.m_csr.mstatus_fs_rmask;
-    rvfi_csr_mstatus_wmask = new_rvfi_trace.m_csr.mstatus_wmask;
+    rvfi_csr_mstatus_wmask = new_rvfi_trace.m_csr.mstatus_wmask & MSTATUS_WRITE_MASK;
     rvfi_csr_mstatus_wmask[31] = new_rvfi_trace.m_csr.mstatus_fs_wmask[31];
     rvfi_csr_mstatus_wmask[14:13] = new_rvfi_trace.m_csr.mstatus_fs_wmask[14:13];
 
@@ -870,7 +884,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     end
     rvfi_csr_mstatus_wdata[30:18] = '0;
     // MPRV is not implemented in the target configuration, writes to it are ignored
-    rvfi_csr_mstatus_wdata[17] = 1'b0;//new_rvfi_trace.m_csr.mstatus_wdata.mprv;
+    rvfi_csr_mstatus_wdata[17] = 1'b0;  //new_rvfi_trace.m_csr.mstatus_wdata.mprv;
     rvfi_csr_mstatus_wdata[16:15] = '0;
     if (FPU == 1 && ZFINX == 0) begin
       rvfi_csr_mstatus_wdata[14:13] = new_rvfi_trace.m_csr.mstatus_fs_wdata;
@@ -882,11 +896,11 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     rvfi_csr_mstatus_wdata[7] = new_rvfi_trace.m_csr.mstatus_wdata.mpie;
     rvfi_csr_mstatus_wdata[6:5] = '0;
     // UPIE is not implemented in the target configuration, writes to it are ignored
-    rvfi_csr_mstatus_wdata[4] = 1'b0;//new_rvfi_trace.m_csr.mstatus_wdata.upie;
+    rvfi_csr_mstatus_wdata[4] = 1'b0;  //new_rvfi_trace.m_csr.mstatus_wdata.upie;
     rvfi_csr_mstatus_wdata[3] = new_rvfi_trace.m_csr.mstatus_wdata.mie;
     rvfi_csr_mstatus_wdata[2:1] = '0;
     // UIE is not implemented in the target configuration, writes to it are ignored
-    rvfi_csr_mstatus_wdata[0] = 1'b0;//new_rvfi_trace.m_csr.mstatus_wdata.uie;
+    rvfi_csr_mstatus_wdata[0] = 1'b0;  //new_rvfi_trace.m_csr.mstatus_wdata.uie;
 
     `SET_RVFI_CSR_FROM_INSN(misa)
     `SET_RVFI_CSR_FROM_INSN(mie)
@@ -1111,6 +1125,9 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
    * The third updates the rvfi interface
    */
   `define CSR_FROM_PIPE(TRACE_NAME, CSR_NAME) \
+    if(!trace_``TRACE_NAME``.m_csr.``CSR_NAME``_we) begin \
+      trace_``TRACE_NAME``.m_csr.``CSR_NAME``_wdata   = r_pipe_freeze_trace.csr.``CSR_NAME``_n; \
+    end\
     if (r_pipe_freeze_trace.csr.``CSR_NAME``_we) begin \
       trace_``TRACE_NAME``.m_csr.``CSR_NAME``_we      = r_pipe_freeze_trace.csr.``CSR_NAME``_we; \
       trace_``TRACE_NAME``.m_csr.``CSR_NAME``_wdata   = r_pipe_freeze_trace.csr.``CSR_NAME``_n; \
@@ -1120,9 +1137,14 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     trace_``TRACE_NAME``.m_csr.``CSR_NAME``_rmask   = '1;
 
   event e_mstatus_to_id;
+  event e_fregs_dirty_1, e_fregs_dirty_2, e_fregs_dirty_3;
   function void mstatus_to_id();
     `CSR_FROM_PIPE(id, mstatus)
     `CSR_FROM_PIPE(id, mstatus_fs)
+    if(r_pipe_freeze_trace.csr.fregs_we && !r_pipe_freeze_trace.csr.mstatus_fs_we && !(r_pipe_freeze_trace.csr.we && r_pipe_freeze_trace.csr.mstatus_fs_we)) begin //writes happening in ex that needs to be reported to id
+      trace_id.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
+      ->e_fregs_dirty_2;
+    end
     ->e_mstatus_to_id;
   endfunction
   //those event are for debug purpose
@@ -1133,10 +1155,11 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       e_dev_commit_rf_to_ex_3,
       e_dev_commit_rf_to_ex_4,
       e_dev_commit_rf_to_ex_5;
-  event e_if_2_id_1, e_if_2_id_2;
+  event e_if_2_id_1, e_if_2_id_2, e_if_2_id_3, e_if_2_id_4;
   event e_ex_to_wb_1, e_ex_to_wb_2;
   event e_id_to_ex_1, e_id_to_ex_2;
   event e_commit_dpc;
+  event e_csr_in_ex, e_csr_irq;
 
   event e_send_rvfi_trace_apu_resp;
   event
@@ -1160,11 +1183,16 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
     `CSR_FROM_PIPE(apu_resp, fcsr)
     `CSR_FROM_PIPE(apu_resp, fflags)
 
-    // `CSR_FROM_PIPE(apu_resp, mstatus)
     `CSR_FROM_PIPE(apu_resp, mstatus_fs)
 
-    if (r_pipe_freeze_trace.csr.mstatus_we) begin
+    if (r_pipe_freeze_trace.csr.mstatus_fs_we && (trace_id.m_order > trace_apu_resp.m_order)) begin
+      trace_id.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
+    end
+    if (r_pipe_freeze_trace.csr.mstatus_fs_we && (trace_ex.m_order > trace_apu_resp.m_order)) begin
       trace_ex.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
+    end
+    if (r_pipe_freeze_trace.csr.mstatus_fs_we && (trace_wb.m_order > trace_apu_resp.m_order)) begin
+      trace_wb.m_csr.mstatus_fs_rdata = r_pipe_freeze_trace.csr.mstatus_fs_n;
     end
   endfunction
 
@@ -1243,14 +1271,22 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
   bit s_is_irq_start;
   bit s_id_done;
   function void if_to_id();
+    if (trace_id.m_valid) begin
+      `CSR_FROM_PIPE(id, misa)
+      `CSR_FROM_PIPE(id, tdata1)
+      `CSR_FROM_PIPE(id, tdata2)
+      tinfo_to_id();
+      `CSR_FROM_PIPE(id, mip)
+      send_rvfi(trace_id);
+    end
     trace_id.init(trace_if);
     trace_id.m_trap       = ~r_pipe_freeze_trace.minstret;
-    trace_id.m_is_illegal = r_pipe_freeze_trace.is_illegal;
+    trace_id.m_is_illegal = trace_id.m_is_illegal | r_pipe_freeze_trace.is_illegal;
+    `CSR_FROM_PIPE(id, dpc)
     s_is_pc_set           = 1'b0;
     s_is_irq_start        = 1'b0;
     trace_if.m_valid      = 1'b0;
     s_id_done             = 1'b0;
-    `CSR_FROM_PIPE(id, dpc)
   endfunction
 
   function logic [31:0] be_to_mask(logic [3:0] be);
@@ -1280,34 +1316,44 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
     bit s_core_is_decoding;  // For readability, ctrl_fsm is DECODE or DECODE_HWLOOP
 
-    trace_if            = new();
-    trace_id            = new();
-    trace_ex            = new();
-    trace_wb            = new();
-    s_new_valid_insn    = 1'b0;
-    s_ex_valid_adjusted = 1'b0;
+    bit s_ex_reg_we_adjusted;  //ex_reg_we
+    bit s_rf_we_wb_adjusted;  //
 
-    s_id_done           = 1'b0;
-    s_apu_wb_ok         = 1'b0;
-    s_apu_0_cycle_reps  = 1'b0;
+    bit s_dont_override_mstatus_fs_id;
 
-    next_send           = 1;
-    cnt_data_req        = 0;
-    cnt_data_resp       = 0;
-    cnt_apu_req         = 0;
-    cnt_apu_resp        = 0;
-    csr_is_irq          = '0;
-    is_dbg_taken        = '0;
-    s_was_flush         = 1'b0;
+    trace_if             = new();
+    trace_id             = new();
+    trace_ex             = new();
+    trace_wb             = new();
+    s_new_valid_insn     = 1'b0;
+    s_ex_valid_adjusted  = 1'b0;
 
-    s_is_pc_set         = 1'b0;
-    s_is_irq_start      = 1'b0;
+    s_id_done            = 1'b0;
+    s_apu_wb_ok          = 1'b0;
+    s_apu_0_cycle_reps   = 1'b0;
 
-    s_is_pc_set         = 1'b0;
-    s_is_irq_start      = 1'b0;
-    s_skip_wb           = 1'b0;
+    next_send            = 1;
+    cnt_data_req         = 0;
+    cnt_data_resp        = 0;
+    cnt_apu_req          = 0;
+    cnt_apu_resp         = 0;
+    csr_is_irq           = '0;
+    is_dbg_taken         = '0;
+    s_was_flush          = 1'b0;
 
-    s_core_is_decoding  = 1'b0;
+    s_is_pc_set          = 1'b0;
+    s_is_irq_start       = 1'b0;
+
+    s_is_pc_set          = 1'b0;
+    s_is_irq_start       = 1'b0;
+    s_skip_wb            = 1'b0;
+
+    s_core_is_decoding   = 1'b0;
+
+    s_ex_reg_we_adjusted = 1'b0;
+    s_rf_we_wb_adjusted  = 1'b0;
+
+    s_dont_override_mstatus_fs_id = 1'b0;
 
     forever begin
       wait(e_pipe_monitor_ok.triggered);  // event triggered
@@ -1325,19 +1371,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       end
 
       if (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_ID && r_pipe_freeze_trace.ebrk_insn_dec) begin
-        if (trace_wb.m_valid) begin
-          send_rvfi(trace_wb);
-          trace_wb.m_valid = 1'b0;
-          ->e_send_rvfi_trace_wb_1;
-        end
-        if (trace_ex.m_valid) begin
-          send_rvfi(trace_ex);
-          trace_ex.m_valid = 1'b0;
-          ->e_send_rvfi_trace_ex_1;
-        end
         if (trace_id.m_valid) begin
-
-          minstret_to_id();
           `CSR_FROM_PIPE(id, misa)
           `CSR_FROM_PIPE(id, tdata1)
           `CSR_FROM_PIPE(id, tdata2)
@@ -1387,7 +1421,9 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
 
       s_new_valid_insn = r_pipe_freeze_trace.id_valid && r_pipe_freeze_trace.is_decoding;// && !r_pipe_freeze_trace.apu_rvalid;
 
-      s_wb_valid_adjusted = r_pipe_freeze_trace.wb_valid && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX));// && !r_pipe_freeze_trace.apu_rvalid;;
+      s_wb_valid_adjusted = r_pipe_freeze_trace.wb_valid && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX) || (r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_WB) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_FLUSH) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_ID) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF));// && !r_pipe_freeze_trace.apu_rvalid;;
+      s_ex_reg_we_adjusted = r_pipe_freeze_trace.ex_reg_we && r_pipe_freeze_trace.mult_ready && r_pipe_freeze_trace.alu_ready && r_pipe_freeze_trace.lsu_ready_ex && !s_apu_to_alu_port;
+      s_rf_we_wb_adjusted = r_pipe_freeze_trace.rf_we_wb && (~r_pipe_freeze_trace.data_misaligned_ex && r_pipe_freeze_trace.wb_ready) && (!s_apu_to_lsu_port || r_pipe_freeze_trace.wb_contention_lsu);
 
       s_fflags_we_non_apu = 1'b0;
       if (r_pipe_freeze_trace.csr.fflags_we) begin
@@ -1418,60 +1454,55 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           s_skip_wb = 1'b1;
         end
       end
-      if (trace_wb.m_valid && !s_skip_wb) begin
-        if (r_pipe_freeze_trace.rf_we_wb) begin
-          if((trace_wb.m_rd_addr[0] == r_pipe_freeze_trace.rf_addr_wb) && (cnt_data_resp == trace_wb.m_mem_req_id[0]) && trace_wb.m_mem_req_id_valid[0]) begin
-            trace_wb.m_rd_addr[0] = r_pipe_freeze_trace.rf_addr_wb;
-            trace_wb.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
-            trace_wb.m_mem_req_id_valid[0] = 1'b0;
-          end else if (trace_wb.m_2_rd_insn && (trace_wb.m_rd_addr[1] == r_pipe_freeze_trace.rf_addr_wb) && (cnt_data_resp == trace_wb.m_mem_req_id[1]) && trace_wb.m_mem_req_id_valid[1]) begin
-            trace_wb.m_rd_addr[1] = r_pipe_freeze_trace.rf_addr_wb;
-            trace_wb.m_rd_wdata[1] = r_pipe_freeze_trace.rf_wdata_wb;
-            trace_wb.m_mem_req_id_valid[1] = 1'b0;
-          end
+
+      if (trace_wb.m_valid && !s_skip_wb && s_rf_we_wb_adjusted) begin
+        if (trace_wb.m_2_rd_insn) begin
+          trace_wb.m_rd_addr[1]  = r_pipe_freeze_trace.rf_addr_wb;
+          trace_wb.m_rd_wdata[1] = r_pipe_freeze_trace.rf_wdata_wb;
+        end else if (trace_wb.m_ex_fw) begin
+          trace_wb.m_rd_addr[1]  = r_pipe_freeze_trace.rf_addr_wb;
+          trace_wb.m_rd_wdata[1] = r_pipe_freeze_trace.rf_wdata_wb;
+          trace_wb.m_2_rd_insn   = 1'b1;
+        end else begin
+          trace_wb.m_rd_addr[0]  = r_pipe_freeze_trace.rf_addr_wb;
+          trace_wb.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
         end
 
-        if (!trace_wb.m_data_missaligned) begin
-          send_rvfi(trace_wb);
-          ->e_dev_send_wb_1; ->e_send_rvfi_trace_wb_2;
-          trace_wb.m_valid = 1'b0;
-        end else begin
-          if (s_wb_valid_adjusted) begin
-            if (r_pipe_freeze_trace.rf_we_wb) begin
-              if (!trace_wb.m_ex_fw) begin
-                trace_wb.m_rd_addr[0]  = r_pipe_freeze_trace.rf_addr_wb;
-                trace_wb.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
-              end
-              if (trace_wb.m_data_missaligned && !trace_wb.m_got_first_data) begin
-                trace_wb.m_got_first_data = 1'b1;
-              end else begin
-                send_rvfi(trace_wb);
-                ->e_dev_send_wb_2; ->e_send_rvfi_trace_wb_3;
-                trace_wb.m_valid = 1'b0;
-              end
-            end  // rf_we_wb
+        if (r_pipe_freeze_trace.csr.fregs_we) begin
+          `CSR_FROM_PIPE(wb, mstatus_fs)
+          trace_wb.m_csr.mstatus_fs_we = 1'b1;
+          trace_wb.m_csr.mstatus_fs_wmask = '1;
+          if(r_pipe_freeze_trace.csr.we && r_pipe_freeze_trace.csr.mstatus_fs_we) begin //In this specific case, two writes to mstatus_fs happen at the same time. We need to recreate the writes caused by fregs_we
+            trace_wb.m_csr.mstatus_fs_wdata = FS_DIRTY;
           end
+          ->e_fregs_dirty_1;
         end
+
+        send_rvfi(trace_wb);
+        ->e_dev_send_wb_1; ->e_send_rvfi_trace_wb_2;
+        trace_wb.m_valid = 1'b0;
+
       end
 
       if (trace_ex.m_valid) begin
-
-        if (!trace_ex.m_csr.got_minstret) begin
+        if(trace_ex.m_instret_smaple_trigger == 1) begin //time to sample instret
           minstret_to_ex();
         end
+        trace_ex.m_instret_smaple_trigger = trace_ex.m_instret_smaple_trigger + 1;
+
         `CSR_FROM_PIPE(ex, misa)
         `CSR_FROM_PIPE(ex, tdata1)
         `CSR_FROM_PIPE(ex, tdata2)
         tinfo_to_ex();
 
-        if (r_pipe_freeze_trace.regfile_we_lsu) begin
+        if (s_rf_we_wb_adjusted) begin
           ->e_dev_commit_rf_to_ex_4;
-          if ((cnt_data_resp == trace_ex.m_mem_req_id[0]) && !(trace_ex.m_got_ex_reg) && trace_ex.m_mem_req_id_valid[0]) begin
+          if (!(trace_ex.m_got_ex_reg) && trace_ex.m_mem_req_id_valid[0]) begin
             trace_ex.m_rd_addr[0] = r_pipe_freeze_trace.rf_addr_wb;
             trace_ex.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
             trace_ex.m_got_first_data = 1'b1;
             trace_ex.m_mem_req_id_valid[0] = 1'b0;
-          end else if ((cnt_data_resp == trace_ex.m_mem_req_id[1])  && trace_ex.m_mem_req_id_valid[1]) begin
+          end else if (trace_ex.m_mem_req_id_valid[1]) begin
             trace_ex.m_rd_addr[1] = r_pipe_freeze_trace.rf_addr_wb;
             trace_ex.m_rd_wdata[1] = r_pipe_freeze_trace.rf_wdata_wb;
             trace_ex.m_got_first_data = 1'b1;
@@ -1485,7 +1516,8 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             trace_ex.m_valid = 1'b0;
             ->e_send_rvfi_trace_ex_2;
           end else begin
-            if (r_pipe_freeze_trace.rf_we_wb && !s_apu_to_lsu_port) begin
+
+            if (s_rf_we_wb_adjusted) begin
               ->e_dev_commit_rf_to_ex_1;
               if (trace_ex.m_got_ex_reg) begin
                 trace_ex.m_rd_addr[1] = r_pipe_freeze_trace.rf_addr_wb;
@@ -1497,24 +1529,35 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
                 trace_ex.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
                 trace_ex.m_got_first_data = 1'b1;
               end
-            end
 
-            if (!s_ex_valid_adjusted & !trace_ex.m_csr.got_minstret) begin
-              minstret_to_ex();
-            end
-            if (trace_ex.m_is_load) begin  // only move relevant instr in wb stage
-              ->e_ex_to_wb_1;
-              trace_wb.move_down_pipe(trace_ex);
-            end else begin
-              if (!trace_ex.m_csr.got_minstret) begin
-                minstret_to_ex();
+              if (r_pipe_freeze_trace.csr.fregs_we && !r_pipe_freeze_trace.apu_rvalid) begin //Catching mstatus_fs updates caused by flw
+                `CSR_FROM_PIPE(ex, mstatus_fs)
+                trace_ex.m_csr.mstatus_fs_we = 1'b1;
+                trace_ex.m_csr.mstatus_fs_wmask = '1;
+                if(r_pipe_freeze_trace.csr.we && r_pipe_freeze_trace.csr.mstatus_fs_we) begin //In this specific case, two writes to mstatus_fs happen at the same time. We need to recreate the writes caused by fregs_we
+                  trace_ex.m_csr.mstatus_fs_wdata = FS_DIRTY;
+                end else begin
+                  trace_id.m_csr.mstatus_fs_rdata = trace_ex.m_csr.mstatus_fs_wdata;
+                  s_dont_override_mstatus_fs_id = 1'b1;
+                end
+                ->e_fregs_dirty_3;
               end
+
               send_rvfi(trace_ex);
-              ->e_send_rvfi_trace_ex_6;
+              trace_ex.m_valid = 1'b0;
+
+            end else begin
+              if (trace_ex.m_is_load) begin  // only move relevant instr in wb stage
+                ->e_ex_to_wb_1;
+                trace_wb.move_down_pipe(trace_ex);
+              end else begin
+                send_rvfi(trace_ex);
+                ->e_send_rvfi_trace_ex_6;
+              end
+              trace_ex.m_valid = 1'b0;
             end
-            trace_ex.m_valid = 1'b0;
           end
-        end else if (r_pipe_freeze_trace.rf_we_wb && !s_apu_to_lsu_port && !s_was_flush) begin
+        end else if (s_rf_we_wb_adjusted && !s_was_flush) begin
           ->e_dev_commit_rf_to_ex_2;
           if (trace_ex.m_got_ex_reg) begin
             trace_ex.m_rd_addr[1] = r_pipe_freeze_trace.rf_addr_wb;
@@ -1529,21 +1572,38 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
         end
       end
 
-      s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF)) && (!r_pipe_freeze_trace.apu_rvalid || r_pipe_freeze_trace.data_req_ex);
+      // If mret, we need to keep the instruction in Id during flush_ex because mstatus update happens at that time
+      s_ex_valid_adjusted = (r_pipe_freeze_trace.ex_valid && r_pipe_freeze_trace.ex_ready) && (s_core_is_decoding || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_IF) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_TAKEN_ID) || (r_pipe_freeze_trace.ctrl_fsm_cs == DBG_FLUSH) || ((r_pipe_freeze_trace.ctrl_fsm_cs == FLUSH_EX) && !r_pipe_freeze_trace.mret_insn_dec));
       //EX_STAGE
+
       if (trace_id.m_valid) begin
+        if(trace_id.m_instret_smaple_trigger == 1) begin //time to sample instret
+          minstret_to_id();
+        end
+        trace_id.m_instret_smaple_trigger = trace_id.m_instret_smaple_trigger + 1;
+
+        if(trace_id.m_sample_csr_write_in_ex && !csr_is_irq && !s_is_irq_start) begin //First cycle after id_ready, csr write is asserted in this cycle
+          `CSR_FROM_PIPE(id, mstatus)
+          if(!s_dont_override_mstatus_fs_id) begin
+              `CSR_FROM_PIPE(id, mstatus_fs)
+          end
+          `CSR_FROM_PIPE(id, mepc)
+          `CSR_FROM_PIPE(id, mcause)
+          `CSR_FROM_PIPE(id, dscratch0)
+          `CSR_FROM_PIPE(id, dscratch1)
+          if(r_pipe_freeze_trace.csr.we && (r_pipe_freeze_trace.csr.addr == CSR_DPC)) begin
+            `CSR_FROM_PIPE(id, dpc)
+          end
+          ->e_csr_in_ex;
+        end
+
+        if(r_pipe_freeze_trace.is_decoding) begin
+            trace_id.m_sample_csr_write_in_ex = 1'b0;
+        end
         mtvec_to_id();
 
         `CSR_FROM_PIPE(id, mip)
         `CSR_FROM_PIPE(id, misa)
-
-        if (!csr_is_irq && !s_is_irq_start) begin
-          mstatus_to_id();
-          `CSR_FROM_PIPE(id, mepc)
-          if (trace_id.m_csr.mcause_we == '0) begin  //for debug purpose
-            `CSR_FROM_PIPE(id, mcause)
-          end
-        end
 
         `CSR_FROM_PIPE(id, mcountinhibit)
         `CSR_FROM_PIPE(id, mscratch)
@@ -1552,10 +1612,6 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
         `CSR_FROM_PIPE(id, fflags)
         `CSR_FROM_PIPE(id, frm)
         `CSR_FROM_PIPE(id, fcsr)
-
-        if (r_pipe_freeze_trace.csr.we) begin
-          `CSR_FROM_PIPE(id, dpc)
-        end
 
         if (r_pipe_freeze_trace.csr.dcsr_we) begin
           dcsr_to_id();
@@ -1577,6 +1633,15 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
         trace_ex.m_csr.frm_wmask    = '0;
         trace_ex.m_csr.fcsr_wmask   = '0;
 
+        if(r_pipe_freeze_trace.ctrl_fsm_cs == XRET_JUMP) begin //xret exit pipeline
+            tinfo_to_id();
+            `CSR_FROM_PIPE(id, tdata1)
+            `CSR_FROM_PIPE(id, tdata2)
+            send_rvfi(trace_id);
+            trace_id.m_valid = 1'b0;
+            s_dont_override_mstatus_fs_id = 1'b0;
+        end
+
         if (r_pipe_freeze_trace.apu_req && r_pipe_freeze_trace.apu_gnt) begin
           trace_id.m_is_apu = 1'b1;
           trace_id.m_apu_req_id = cnt_apu_req;
@@ -1586,6 +1651,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           trace_apu_req.set_to_apu();
           apu_trace_q.push_back(trace_apu_req);
           trace_id.m_valid = 1'b0;
+          s_dont_override_mstatus_fs_id = 1'b0;
 
           if(r_pipe_freeze_trace.apu_rvalid && (cnt_apu_req == cnt_apu_resp)) begin//APU return in the same cycle
             apu_resp();
@@ -1603,10 +1669,10 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             trace_id.m_rd_addr[0]  = r_pipe_freeze_trace.ex_reg_addr;
             trace_id.m_rd_wdata[0] = r_pipe_freeze_trace.ex_reg_wdata;
             trace_id.m_got_ex_reg = 1'b1;
-          end else if (!trace_ex.m_valid & r_pipe_freeze_trace.rf_we_wb & !trace_id.m_ex_fw) begin
+          end else if (!trace_ex.m_valid & s_rf_we_wb_adjusted & !trace_id.m_ex_fw) begin
             trace_id.m_rd_addr[0]  = r_pipe_freeze_trace.rf_addr_wb;
             trace_id.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
-          end else if (r_pipe_freeze_trace.rf_we_wb) begin
+          end else if (s_rf_we_wb_adjusted) begin
             trace_id.m_rd_addr[1]  = r_pipe_freeze_trace.rf_addr_wb;
             trace_id.m_rd_wdata[1] = r_pipe_freeze_trace.rf_wdata_wb;
             trace_id.m_2_rd_insn   = 1'b1;
@@ -1621,19 +1687,16 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             trace_id.m_mem.addr = r_pipe_freeze_trace.data_addr_pmp;
             if (r_pipe_freeze_trace.data_misaligned) begin
               cnt_data_req = cnt_data_req + 1;
+              trace_id.m_mem_req_id[0] = cnt_data_req;
             end
+
             if (!r_pipe_freeze_trace.data_we_ex) begin
               trace_id.m_is_load   = 1'b1;
               trace_id.m_mem.wmask = be_to_mask(r_pipe_freeze_trace.lsu_data_be);  //'1;
-              if (r_pipe_freeze_trace.data_misaligned) begin
-                trace_id.m_data_missaligned = 1'b1;
-                trace_id.m_mem_req_id[1] = trace_id.m_mem_req_id[0];
-                trace_id.m_mem_req_id[0] = cnt_data_req;
-                trace_id.m_mem_req_id_valid[1] = 1'b1;
-              end
             end else begin
               trace_id.m_mem.rmask = be_to_mask(r_pipe_freeze_trace.lsu_data_be);  //'1;
             end
+
             if (trace_id.m_got_ex_reg) begin  // Shift index 0 to 1
               trace_id.m_mem_req_id[1] = trace_id.m_mem_req_id[0];
               trace_id.m_mem_req_id[0] = 0;
@@ -1644,6 +1707,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           hwloop_to_id();
           trace_ex.move_down_pipe(trace_id);  // The instruction moves forward from ID to EX
           trace_id.m_valid = 1'b0;
+          s_dont_override_mstatus_fs_id = 1'b0;
           ->e_id_to_ex_1;
 
         end else if (r_pipe_freeze_trace.ex_reg_we && r_pipe_freeze_trace.rf_alu_we_ex) begin
@@ -1667,9 +1731,6 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       if (s_new_valid_insn) begin  // There is a new valid instruction
         if (trace_id.m_valid) begin
           if (trace_ex.m_valid) begin
-            if (!trace_ex.m_csr.got_minstret) begin
-              minstret_to_ex();
-            end
             if (trace_wb.m_valid) begin
               send_rvfi(trace_ex);
               ->e_send_rvfi_trace_ex_4;
@@ -1692,15 +1753,10 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
             trace_id.m_mem.addr = r_pipe_freeze_trace.data_addr_pmp;
             if (r_pipe_freeze_trace.data_misaligned) begin
               cnt_data_req = cnt_data_req + 1;
+              trace_id.m_mem_req_id[0] = cnt_data_req;
             end
             if (!r_pipe_freeze_trace.data_we_ex) begin
               trace_id.m_is_load = 1'b1;
-              if (r_pipe_freeze_trace.data_misaligned) begin
-                trace_id.m_data_missaligned = 1'b1;
-                trace_id.m_mem_req_id[1] = trace_id.m_mem_req_id[0];
-                trace_id.m_mem_req_id[0] = cnt_data_req;
-                trace_id.m_mem_req_id_valid[1] = 1'b1;
-              end
             end
             if (trace_id.m_got_ex_reg) begin  // Shift index 0 to 1
               trace_id.m_mem_req_id[1] = trace_id.m_mem_req_id[0];
@@ -1708,7 +1764,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
               trace_id.m_mem_req_id_valid[0] = 1'b0;
               trace_id.m_mem_req_id_valid[1] = 1'b1;
             end
-          end else if (r_pipe_freeze_trace.rf_we_wb && !r_pipe_freeze_trace.ex_reg_we) begin
+          end else if (s_rf_we_wb_adjusted && !r_pipe_freeze_trace.ex_reg_we) begin
             trace_id.m_rd_addr[0]  = r_pipe_freeze_trace.rf_addr_wb;
             trace_id.m_rd_wdata[0] = r_pipe_freeze_trace.rf_wdata_wb;
           end
@@ -1716,6 +1772,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
           hwloop_to_id();
           trace_ex.move_down_pipe(trace_id);
           trace_id.m_valid = 1'b0;
+          s_dont_override_mstatus_fs_id = 1'b0;
           ->e_id_to_ex_2;
         end
         if_to_id();
@@ -1733,12 +1790,27 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
       end
 
       //IF_STAGE
-      if (r_pipe_freeze_trace.if_valid && r_pipe_freeze_trace.if_ready) begin
-        if(trace_if.m_valid && r_pipe_freeze_trace.id_valid && r_pipe_freeze_trace.id_ready && !trace_id.m_valid && r_pipe_freeze_trace.ebrk_insn_dec) begin
-          if_to_id();
-          trace_id.m_is_ebreak = '1;  //trace_if.m_is_ebreak;
-          ->e_if_2_id_2;
+      if(trace_if.m_valid) begin
+        if(r_pipe_freeze_trace.is_illegal && r_pipe_freeze_trace.is_decoding) begin
+          trace_if.m_is_illegal = 1'b1;
         end
+      end
+
+      if (r_pipe_freeze_trace.if_valid && r_pipe_freeze_trace.if_ready && r_pipe_freeze_trace.instr_valid_if) begin
+        if (trace_if.m_valid) begin
+          if (r_pipe_freeze_trace.id_valid && r_pipe_freeze_trace.id_ready && !trace_id.m_valid && r_pipe_freeze_trace.ebrk_insn_dec) begin
+            if_to_id();
+            trace_id.m_is_ebreak = '1;  //trace_if.m_is_ebreak;
+            ->e_if_2_id_2;
+          end else if (trace_if.m_is_illegal) begin
+            if_to_id();
+            ->e_if_2_id_3;
+          end else if (r_pipe_freeze_trace.ecall_insn_dec) begin
+            if_to_id();
+            ->e_if_2_id_4;
+          end
+        end
+
 
         trace_if.m_insn = r_pipe_freeze_trace.instr_if;  //Instr comes from if, buffer for one cycle
         trace_if.m_pc_rdata = r_pipe_freeze_trace.pc_if;
@@ -1754,6 +1826,7 @@ insn_trace_t trace_if, trace_id, trace_ex, trace_ex_next, trace_wb;
         mstatus_to_id();
         `CSR_FROM_PIPE(id, mepc)
         `CSR_FROM_PIPE(id, mcause)
+        ->e_csr_irq;
       end
 
       if (!s_id_done && r_pipe_freeze_trace.is_decoding) begin

--- a/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_tb_wrapper.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/bhv/cv32e40p_tb_wrapper.sv
@@ -279,8 +279,12 @@ module cv32e40p_tb_wrapper
       // .instr         (cv32e40p_top_i.core_i.id_stage_i.instr     ),
       .is_compressed_id_i(cv32e40p_top_i.core_i.id_stage_i.is_compressed_i),
       .ebrk_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.ebrk_insn_dec),
-      .csr_cause_i       (cv32e40p_top_i.core_i.csr_cause),
-      .debug_csr_save_i  (cv32e40p_top_i.core_i.debug_csr_save),
+      .ecall_insn_dec_i  (cv32e40p_top_i.core_i.id_stage_i.ecall_insn_dec),
+      .mret_insn_dec_i   (cv32e40p_top_i.core_i.id_stage_i.mret_insn_dec),
+      .mret_dec_i        (cv32e40p_top_i.core_i.id_stage_i.mret_dec),
+
+      .csr_cause_i     (cv32e40p_top_i.core_i.csr_cause),
+      .debug_csr_save_i(cv32e40p_top_i.core_i.debug_csr_save),
 
       // HWLOOP regs
       .hwlp_start_q_i  (hwlp_start_q),
@@ -305,9 +309,11 @@ module cv32e40p_tb_wrapper
       // .rf_addr_alu_i  (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_waddr_fw_i),
       // .rf_wdata_alu_i (cv32e40p_top_i.core_i.id_stage_i.regfile_alu_wdata_fw_i),
 
+      .mult_ready_i        (cv32e40p_top_i.core_i.ex_stage_i.mult_ready),
+      .alu_ready_i         (cv32e40p_top_i.core_i.ex_stage_i.alu_ready),
       //// WB probes ////
-      .wb_valid_i(cv32e40p_top_i.core_i.wb_valid),
-
+      .wb_valid_i          (cv32e40p_top_i.core_i.wb_valid),
+      .wb_ready_i          (cv32e40p_top_i.core_i.lsu_ready_wb),
       //// LSU probes ////
       .data_we_ex_i        (cv32e40p_top_i.core_i.data_we_ex),
       .data_atop_ex_i      (cv32e40p_top_i.core_i.data_atop_ex),
@@ -359,6 +365,8 @@ module cv32e40p_tb_wrapper
       .csr_addr_i     (cv32e40p_top_i.core_i.cs_registers_i.csr_addr_i),
       .csr_we_i       (cv32e40p_top_i.core_i.cs_registers_i.csr_we_int),
       .csr_wdata_int_i(cv32e40p_top_i.core_i.cs_registers_i.csr_wdata_int),
+
+      .csr_fregs_we_i(cv32e40p_top_i.core_i.cs_registers_i.fregs_we_i),
 
       .csr_mstatus_n_i   (cv32e40p_top_i.core_i.cs_registers_i.mstatus_n),
       .csr_mstatus_q_i   (cv32e40p_top_i.core_i.cs_registers_i.mstatus_q),

--- a/hw/vendor/openhwgroup_cv32e40p/bhv/include/cv32e40p_tracer_pkg.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/bhv/include/cv32e40p_tracer_pkg.sv
@@ -196,8 +196,8 @@ package cv32e40p_tracer_pkg;
   parameter INSTR_CVEND0 = {12'b000000000000, 5'b?, 3'b100, 4'b0011, 1'b0, OPCODE_CUSTOM_1};
   parameter INSTR_CVCOUNTI0 = {12'b?, 5'b00000, 3'b100, 4'b0100, 1'b0, OPCODE_CUSTOM_1};
   parameter INSTR_CVCOUNT0 = {12'b000000000000, 5'b?, 3'b100, 4'b0101, 1'b0, OPCODE_CUSTOM_1};
-  parameter INSTR_CVSETUPI0 = {12'b?, 5'b00000, 3'b100, 4'b0110, 1'b0, OPCODE_CUSTOM_1};
-  parameter INSTR_CVSETUP0 = {12'b?, 5'b00000, 3'b100, 4'b0111, 1'b0, OPCODE_CUSTOM_1};
+  parameter INSTR_CVSETUPI0 = {17'b?, 3'b100, 4'b0110, 1'b0, OPCODE_CUSTOM_1};
+  parameter INSTR_CVSETUP0 = {12'b?, 5'b?, 3'b100, 4'b0111, 1'b0, OPCODE_CUSTOM_1};
 
   parameter INSTR_CVSTARTI1 = {12'b?, 5'b00000, 3'b100, 4'b0000, 1'b1, OPCODE_CUSTOM_1};
   parameter INSTR_CVSTART1 = {12'b000000000000, 5'b?, 3'b100, 4'b0001, 1'b1, OPCODE_CUSTOM_1};
@@ -205,8 +205,8 @@ package cv32e40p_tracer_pkg;
   parameter INSTR_CVEND1 = {12'b000000000000, 5'b?, 3'b100, 4'b0011, 1'b1, OPCODE_CUSTOM_1};
   parameter INSTR_CVCOUNTI1 = {12'b?, 5'b00000, 3'b100, 4'b0100, 1'b1, OPCODE_CUSTOM_1};
   parameter INSTR_CVCOUNT1 = {12'b000000000000, 5'b?, 3'b100, 4'b0101, 1'b1, OPCODE_CUSTOM_1};
-  parameter INSTR_CVSETUPI1 = {12'b?, 5'b00000, 3'b100, 4'b0110, 1'b1, OPCODE_CUSTOM_1};
-  parameter INSTR_CVSETUP1 = {12'b?, 5'b00000, 3'b100, 4'b0111, 1'b1, OPCODE_CUSTOM_1};
+  parameter INSTR_CVSETUPI1 = {17'b?, 3'b100, 4'b0110, 1'b1, OPCODE_CUSTOM_1};
+  parameter INSTR_CVSETUP1 = {12'b?, 5'b?, 3'b100, 4'b0111, 1'b1, OPCODE_CUSTOM_1};
 
 
   parameter INSTR_FF1 = {7'b0100001, 5'b0, 5'b?, 3'b011, 5'b?, OPCODE_CUSTOM_1};
@@ -449,8 +449,8 @@ package cv32e40p_tracer_pkg;
   parameter INSTR_CVSHUFFLE2H = {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
   parameter INSTR_CVSHUFFLE2B = {5'b11100, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
 
-  parameter INSTR_CVPACK = {5'b11101, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
-  parameter INSTR_CVPACKH = {5'b11101, 1'b0, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+  parameter INSTR_CVPACK = {5'b11110, 1'b0, 1'b0, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
+  parameter INSTR_CVPACKH = {5'b11110, 1'b0, 1'b1, 5'b?, 5'b?, 3'b000, 5'b?, OPCODE_CUSTOM_3};
 
   parameter INSTR_CVPACKHIB = {5'b11111, 1'b0, 1'b1, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};
   parameter INSTR_CVPACKLOB = {5'b11111, 1'b0, 1'b0, 5'b?, 5'b?, 3'b001, 5'b?, OPCODE_CUSTOM_3};

--- a/hw/vendor/openhwgroup_cv32e40p/bhv/insn_trace.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/bhv/insn_trace.sv
@@ -65,6 +65,9 @@
     bit m_move_down_pipe;
 
     int m_instret_cnt;
+    int m_instret_smaple_trigger; //We need to sample minstret from csr 2 cycle after id is doen
+
+    bit m_sample_csr_write_in_ex;
 
     struct {
       logic [31:0] addr ;
@@ -145,32 +148,34 @@
 
 
     function new();
-      this.m_order             = 0;
-      this.m_skip_order        = 1'b0;
-      this.m_valid             = 1'b0;
-      this.m_move_down_pipe    = 1'b0;
-      this.m_data_missaligned  = 1'b0;
-      this.m_got_first_data    = 1'b0;
-      this.m_got_ex_reg        = 1'b0;
-      this.m_intr              = '0;
-      this.m_dbg_taken         = 1'b0;
-      this.m_dbg_cause         = '0;
-      this.m_is_ebreak         = '0;
-      this.m_is_illegal        = '0;
-      this.m_is_irq            = '0;
-      this.m_is_memory         = 1'b0;
-      this.m_is_load           = 1'b0;
-      this.m_is_apu            = 1'b0;
-      this.m_is_apu_ok         = 1'b0;
-      this.m_apu_req_id        = 0;
-      this.m_mem_req_id[0]     = 0;
-      this.m_mem_req_id[1]     = 0;
-      this.m_mem_req_id_valid  = '0;
-      this.m_trap              = 1'b0;
-      this.m_fflags_we_non_apu = 1'b0;
-      this.m_frm_we_non_apu    = 1'b0;
-      this.m_fcsr_we_non_apu   = 1'b0;
-      this.m_instret_cnt       = 0;
+      this.m_order                  = 0;
+      this.m_skip_order             = 1'b0;
+      this.m_valid                  = 1'b0;
+      this.m_move_down_pipe         = 1'b0;
+      this.m_data_missaligned       = 1'b0;
+      this.m_got_first_data         = 1'b0;
+      this.m_got_ex_reg             = 1'b0;
+      this.m_intr                   = '0;
+      this.m_dbg_taken              = 1'b0;
+      this.m_dbg_cause              = '0;
+      this.m_is_ebreak              = '0;
+      this.m_is_illegal             = '0;
+      this.m_is_irq                 = '0;
+      this.m_is_memory              = 1'b0;
+      this.m_is_load                = 1'b0;
+      this.m_is_apu                 = 1'b0;
+      this.m_is_apu_ok              = 1'b0;
+      this.m_apu_req_id             = 0;
+      this.m_mem_req_id[0]          = 0;
+      this.m_mem_req_id[1]          = 0;
+      this.m_mem_req_id_valid       = '0;
+      this.m_trap                   = 1'b0;
+      this.m_fflags_we_non_apu      = 1'b0;
+      this.m_frm_we_non_apu         = 1'b0;
+      this.m_fcsr_we_non_apu        = 1'b0;
+      this.m_instret_cnt            = 0;
+      this.m_instret_smaple_trigger = 0;
+      this.m_sample_csr_write_in_ex = 1'b1;
     endfunction
 
     function void get_mnemonic();
@@ -875,37 +880,39 @@
       if(this.m_skip_order) begin
         this.m_order            = this.m_order + 64'h1;
       end
-      this.m_skip_order        = 1'b0;
-      this.m_pc_rdata          = r_pipe_freeze_trace.pc_id;
-      this.m_is_illegal        = 1'b0;
-      this.m_is_irq            = 1'b0;
-      this.m_is_memory         = 1'b0;
-      this.m_is_load           = 1'b0;
-      this.m_is_apu            = 1'b0;
-      this.m_is_apu_ok         = 1'b0;
-      this.m_apu_req_id        = 0;
-      this.m_mem_req_id[0]     = 0;
-      this.m_mem_req_id[1]     = 0;
-      this.m_mem_req_id_valid  = '0;
-      this.m_data_missaligned  = 1'b0;
-      this.m_got_first_data    = 1'b0;
-      this.m_got_ex_reg        = 1'b0;
-      this.m_got_regs_write    = 1'b0;
-      this.m_move_down_pipe    = 1'b0;
-      this.m_instret_cnt       = 0;
-      this.m_rd_addr[0]        = '0;
-      this.m_rd_addr[1]        = '0;
-      this.m_2_rd_insn         = 1'b0;
-      this.m_rs1_addr          = '0;
-      this.m_rs2_addr          = '0;
-      this.m_rs3_addr          = '0;
-      this.m_ex_fw             = '0;
-      this.m_csr.got_minstret  = '0;
-      this.m_dbg_taken         = '0;
-      this.m_trap              = 1'b0;
-      this.m_fflags_we_non_apu = 1'b0;
-      this.m_frm_we_non_apu    = 1'b0;
-      this.m_fcsr_we_non_apu   = 1'b0;
+      this.m_skip_order             = 1'b0;
+      this.m_pc_rdata               = r_pipe_freeze_trace.pc_id;
+      this.m_is_illegal             = 1'b0;
+      this.m_is_irq                 = 1'b0;
+      this.m_is_memory              = 1'b0;
+      this.m_is_load                = 1'b0;
+      this.m_is_apu                 = 1'b0;
+      this.m_is_apu_ok              = 1'b0;
+      this.m_apu_req_id             = 0;
+      this.m_mem_req_id[0]          = 0;
+      this.m_mem_req_id[1]          = 0;
+      this.m_mem_req_id_valid       = '0;
+      this.m_data_missaligned       = 1'b0;
+      this.m_got_first_data         = 1'b0;
+      this.m_got_ex_reg             = 1'b0;
+      this.m_got_regs_write         = 1'b0;
+      this.m_move_down_pipe         = 1'b0;
+      this.m_instret_cnt            = 0;
+      this.m_instret_smaple_trigger = 0;
+      this.m_sample_csr_write_in_ex = 1'b1;
+      this.m_rd_addr[0]             = '0;
+      this.m_rd_addr[1]             = '0;
+      this.m_2_rd_insn              = 1'b0;
+      this.m_rs1_addr               = '0;
+      this.m_rs2_addr               = '0;
+      this.m_rs3_addr               = '0;
+      this.m_ex_fw                  = '0;
+      this.m_csr.got_minstret       = '0;
+      this.m_dbg_taken              = '0;
+      this.m_trap                   = 1'b0;
+      this.m_fflags_we_non_apu      = 1'b0;
+      this.m_frm_we_non_apu         = 1'b0;
+      this.m_fcsr_we_non_apu        = 1'b0;
       this.m_csr.mcause_we = '0;
       if (is_compressed_id_i) begin
         this.m_insn[31:16] = '0;
@@ -944,47 +951,49 @@
     endfunction
 
     function void copy_full(insn_trace_t m_source);
-      this.m_valid              = m_source.m_valid;
-      this.m_stage              = m_source.m_stage;
-      this.m_order              = m_source.m_order;
-      this.m_pc_rdata           = m_source.m_pc_rdata;
-      this.m_insn               = m_source.m_insn;
-      this.m_mnemonic           = m_source.m_mnemonic;
-      this.m_is_memory          = m_source.m_is_memory;
-      this.m_is_load            = m_source.m_is_load;
-      this.m_is_apu             = m_source.m_is_apu;
-      this.m_is_apu_ok          = m_source.m_is_apu_ok;
-      this.m_apu_req_id         = m_source.m_apu_req_id;
-      this.m_mem_req_id         = m_source.m_mem_req_id;
-      this.m_mem_req_id_valid   = m_source.m_mem_req_id_valid;
-      this.m_data_missaligned   = m_source.m_data_missaligned;
-      this.m_got_first_data     = m_source.m_got_first_data;
-      this.m_got_ex_reg         = m_source.m_got_ex_reg;
-      this.m_dbg_taken          = m_source.m_dbg_taken;
-      this.m_dbg_cause          = m_source.m_dbg_cause;
-      this.m_is_ebreak          = m_source.m_is_ebreak;
-      this.m_is_illegal         = m_source.m_is_illegal;
-      this.m_is_irq             = m_source.m_is_irq;
-      this.m_instret_cnt        = m_source.m_instret_cnt;
-      this.m_rs1_addr           = m_source.m_rs1_addr;
-      this.m_rs2_addr           = m_source.m_rs2_addr;
-      this.m_rs3_addr           = m_source.m_rs3_addr;
-      this.m_rs1_rdata          = m_source.m_rs1_rdata;
-      this.m_rs2_rdata          = m_source.m_rs2_rdata;
-      this.m_rs3_rdata          = m_source.m_rs3_rdata;
+      this.m_valid                  = m_source.m_valid;
+      this.m_stage                  = m_source.m_stage;
+      this.m_order                  = m_source.m_order;
+      this.m_pc_rdata               = m_source.m_pc_rdata;
+      this.m_insn                   = m_source.m_insn;
+      this.m_mnemonic               = m_source.m_mnemonic;
+      this.m_is_memory              = m_source.m_is_memory;
+      this.m_is_load                = m_source.m_is_load;
+      this.m_is_apu                 = m_source.m_is_apu;
+      this.m_is_apu_ok              = m_source.m_is_apu_ok;
+      this.m_apu_req_id             = m_source.m_apu_req_id;
+      this.m_mem_req_id             = m_source.m_mem_req_id;
+      this.m_mem_req_id_valid       = m_source.m_mem_req_id_valid;
+      this.m_data_missaligned       = m_source.m_data_missaligned;
+      this.m_got_first_data         = m_source.m_got_first_data;
+      this.m_got_ex_reg             = m_source.m_got_ex_reg;
+      this.m_dbg_taken              = m_source.m_dbg_taken;
+      this.m_dbg_cause              = m_source.m_dbg_cause;
+      this.m_is_ebreak              = m_source.m_is_ebreak;
+      this.m_is_illegal             = m_source.m_is_illegal;
+      this.m_is_irq                 = m_source.m_is_irq;
+      this.m_instret_cnt            = m_source.m_instret_cnt;
+      this.m_instret_smaple_trigger = m_source.m_instret_smaple_trigger;
+      this.m_sample_csr_write_in_ex = m_source.m_sample_csr_write_in_ex;
+      this.m_rs1_addr               = m_source.m_rs1_addr;
+      this.m_rs2_addr               = m_source.m_rs2_addr;
+      this.m_rs3_addr               = m_source.m_rs3_addr;
+      this.m_rs1_rdata              = m_source.m_rs1_rdata;
+      this.m_rs2_rdata              = m_source.m_rs2_rdata;
+      this.m_rs3_rdata              = m_source.m_rs3_rdata;
 
-      this.m_ex_fw              = m_source.m_ex_fw;
-      this.m_rd_addr            = m_source.m_rd_addr;
-      this.m_2_rd_insn          = m_source.m_2_rd_insn;
-      this.m_rd_wdata           = m_source.m_rd_wdata;
+      this.m_ex_fw                  = m_source.m_ex_fw;
+      this.m_rd_addr                = m_source.m_rd_addr;
+      this.m_2_rd_insn              = m_source.m_2_rd_insn;
+      this.m_rd_wdata               = m_source.m_rd_wdata;
 
-      this.m_intr               = m_source.m_intr;
-      this.m_trap               = m_source.m_trap;
-      this.m_fflags_we_non_apu  = m_source.m_fflags_we_non_apu;
-      this.m_frm_we_non_apu     = m_source.m_frm_we_non_apu   ;
-      this.m_fcsr_we_non_apu    = m_source.m_fcsr_we_non_apu;
+      this.m_intr                   = m_source.m_intr;
+      this.m_trap                   = m_source.m_trap;
+      this.m_fflags_we_non_apu      = m_source.m_fflags_we_non_apu;
+      this.m_frm_we_non_apu         = m_source.m_frm_we_non_apu   ;
+      this.m_fcsr_we_non_apu        = m_source.m_fcsr_we_non_apu;
 
-      this.m_mem                = m_source.m_mem;
+      this.m_mem                    = m_source.m_mem;
       //CRS
       `ASSIGN_CSR(mstatus)
       `ASSIGN_CSR(mstatus_fs)

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_controller.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_controller.sv
@@ -491,6 +491,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
             if ( (debug_req_pending || trigger_match_i) & ~debug_mode_q )
               begin
                 //Serving the debug
+                is_decoding_o     = COREV_PULP ? 1'b0 : 1'b1;
                 halt_if_o         = 1'b1;
                 halt_id_o         = 1'b1;
                 ctrl_fsm_ns       = DBG_FLUSH;
@@ -712,6 +713,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
             if ( (debug_req_pending || trigger_match_i) & ~debug_mode_q )
               begin
                 //Serving the debug
+                is_decoding_o     = COREV_PULP ? 1'b0 : 1'b1;
                 halt_if_o         = 1'b1;
                 halt_id_o         = 1'b1;
                 ctrl_fsm_ns       = DBG_FLUSH;
@@ -764,7 +766,7 @@ module cv32e40p_controller import cv32e40p_pkg::*;
 
                     ebrk_insn_i: begin
                       halt_if_o     = 1'b1;
-                      halt_id_o     = 1'b1;
+                      halt_id_o     = 1'b0;
 
                       if (debug_mode_q)
                         // we got back to the park loop in the debug rom
@@ -776,15 +778,15 @@ module cv32e40p_controller import cv32e40p_pkg::*;
 
                       else begin
                         // otherwise just a normal ebreak exception
-                        ctrl_fsm_ns = FLUSH_EX;
+                        ctrl_fsm_ns = id_ready_i ? FLUSH_EX : DECODE_HWLOOP;
                       end
 
                     end
 
                     ecall_insn_i: begin
                       halt_if_o     = 1'b1;
-                      halt_id_o     = 1'b1;
-                      ctrl_fsm_ns   = FLUSH_EX;
+                      halt_id_o     = 1'b0;
+                      ctrl_fsm_ns   = id_ready_i ? FLUSH_EX : DECODE_HWLOOP;
                     end
 
                     csr_status_i: begin
@@ -1559,7 +1561,7 @@ endgenerate
 
     // HWLoop 0 and 1 having target address constraints
     property p_hwlp_same_target_address;
-       @(posedge clk) (hwlp_counter_i[1] > 1 && hwlp_counter_i[0] > 1) |-> ( hwlp_end_addr_i[1] - 4 >= hwlp_end_addr_i[0] - 4 + 8 );
+       @(posedge clk) (hwlp_counter_i[1] > 1 && hwlp_counter_i[0] > 1 && pc_id_i >= hwlp_start_addr_i[0] && pc_id_i <= hwlp_end_addr_i[0] - 4) |-> ( hwlp_end_addr_i[1] - 4 >= hwlp_end_addr_i[0] - 4 + 8 );
     endproperty
 
     a_hwlp_same_target_address : assert property(p_hwlp_same_target_address) else $warning("%t, HWLoops target address do not respect constraints", $time);

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_core.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_core.sv
@@ -158,6 +158,7 @@ module cv32e40p_core
   logic [31:0] jump_target_id, jump_target_ex;
   logic               branch_in_ex;
   logic               branch_decision;
+  logic        [ 1:0] ctrl_transfer_insn_in_dec;
 
   logic               ctrl_busy;
   logic               if_busy;
@@ -201,6 +202,7 @@ module cv32e40p_core
   logic        [            C_RM-1:0]       frm_csr;
   logic        [         C_FFLAG-1:0]       fflags_csr;
   logic                                     fflags_we;
+  logic                                     fregs_we;
 
   // APU
   logic                                     apu_en_ex;
@@ -228,6 +230,7 @@ module cv32e40p_core
   logic                                     regfile_we_ex;
   logic        [                 5:0]       regfile_waddr_fw_wb_o;  // From WB to ID
   logic                                     regfile_we_wb;
+  logic                                     regfile_we_wb_power;
   logic        [                31:0]       regfile_wdata;
 
   logic        [                 5:0]       regfile_alu_waddr_ex;
@@ -235,6 +238,7 @@ module cv32e40p_core
 
   logic        [                 5:0]       regfile_alu_waddr_fw;
   logic                                     regfile_alu_we_fw;
+  logic                                     regfile_alu_we_fw_power;
   logic        [                31:0]       regfile_alu_wdata_fw;
 
   // CSR control
@@ -540,9 +544,10 @@ module cv32e40p_core
       .instr_req_o  (instr_req_int),
 
       // Jumps and branches
-      .branch_in_ex_o   (branch_in_ex),
-      .branch_decision_i(branch_decision),
-      .jump_target_o    (jump_target_id),
+      .branch_in_ex_o             (branch_in_ex),
+      .branch_decision_i          (branch_decision),
+      .jump_target_o              (jump_target_id),
+      .ctrl_transfer_insn_in_dec_o(ctrl_transfer_insn_in_dec),
 
       // IF and ID control signals
       .clear_instr_valid_o(clear_instr_valid),
@@ -699,13 +704,15 @@ module cv32e40p_core
       .wake_from_sleep_o(wake_from_sleep),
 
       // Forward Signals
-      .regfile_waddr_wb_i(regfile_waddr_fw_wb_o),  // Write address ex-wb pipeline
-      .regfile_we_wb_i   (regfile_we_wb),  // write enable for the register file
-      .regfile_wdata_wb_i(regfile_wdata),  // write data to commit in the register file
+      .regfile_waddr_wb_i   (regfile_waddr_fw_wb_o),  // Write address ex-wb pipeline
+      .regfile_we_wb_i      (regfile_we_wb),  // write enable for the register file
+      .regfile_we_wb_power_i(regfile_we_wb_power),
+      .regfile_wdata_wb_i   (regfile_wdata),  // write data to commit in the register file
 
-      .regfile_alu_waddr_fw_i(regfile_alu_waddr_fw),
-      .regfile_alu_we_fw_i   (regfile_alu_we_fw),
-      .regfile_alu_wdata_fw_i(regfile_alu_wdata_fw),
+      .regfile_alu_waddr_fw_i   (regfile_alu_waddr_fw),
+      .regfile_alu_we_fw_i      (regfile_alu_we_fw),
+      .regfile_alu_we_fw_power_i(regfile_alu_we_fw_power),
+      .regfile_alu_wdata_fw_i   (regfile_alu_wdata_fw),
 
       // from ALU
       .mult_multicycle_i(mult_multicycle),
@@ -737,6 +744,7 @@ module cv32e40p_core
   //                                                 //
   /////////////////////////////////////////////////////
   cv32e40p_ex_stage #(
+      .COREV_PULP      (COREV_PULP),
       .FPU             (FPU),
       .APU_NARGS_CPU   (APU_NARGS_CPU),
       .APU_WOP_CPU     (APU_WOP_CPU),
@@ -784,6 +792,8 @@ module cv32e40p_core
       .data_rvalid_i       (data_rvalid_i),  // from ID/EX pipeline
       .data_misaligned_ex_i(data_misaligned_ex),  // from ID/EX pipeline
       .data_misaligned_i   (data_misaligned),
+
+      .ctrl_transfer_insn_in_dec_i(ctrl_transfer_insn_in_dec),
 
       // FPU
       .fpu_fflags_we_o(fflags_we),
@@ -838,18 +848,20 @@ module cv32e40p_core
       .regfile_we_i   (regfile_we_ex),
 
       // Output of ex stage pipeline
-      .regfile_waddr_wb_o(regfile_waddr_fw_wb_o),
-      .regfile_we_wb_o   (regfile_we_wb),
-      .regfile_wdata_wb_o(regfile_wdata),
+      .regfile_waddr_wb_o   (regfile_waddr_fw_wb_o),
+      .regfile_we_wb_o      (regfile_we_wb),
+      .regfile_we_wb_power_o(regfile_we_wb_power),
+      .regfile_wdata_wb_o   (regfile_wdata),
 
       // To IF: Jump and branch target and decision
       .jump_target_o    (jump_target_ex),
       .branch_decision_o(branch_decision),
 
       // To ID stage: Forwarding signals
-      .regfile_alu_waddr_fw_o(regfile_alu_waddr_fw),
-      .regfile_alu_we_fw_o   (regfile_alu_we_fw),
-      .regfile_alu_wdata_fw_o(regfile_alu_wdata_fw),
+      .regfile_alu_waddr_fw_o   (regfile_alu_waddr_fw),
+      .regfile_alu_we_fw_o      (regfile_alu_we_fw),
+      .regfile_alu_we_fw_power_o(regfile_alu_we_fw_power),
+      .regfile_alu_wdata_fw_o   (regfile_alu_wdata_fw),
 
       // stall control
       .is_decoding_i (is_decoding),
@@ -969,6 +981,7 @@ module cv32e40p_core
       .frm_o      (frm_csr),
       .fflags_i   (fflags_csr),
       .fflags_we_i(fflags_we),
+      .fregs_we_i (fregs_we),
 
       // Interrupt related control signals
       .mie_bypass_o  (mie_bypass),
@@ -1037,13 +1050,16 @@ module cv32e40p_core
   );
 
   //  CSR access
-  assign csr_addr     = csr_addr_int;
-  assign csr_wdata    = alu_operand_a_ex;
-  assign csr_op       = csr_op_ex;
+  assign csr_addr = csr_addr_int;
+  assign csr_wdata = alu_operand_a_ex;
+  assign csr_op = csr_op_ex;
 
   assign csr_addr_int = csr_num_e'(csr_access_ex ? alu_operand_b_ex[11:0] : '0);
 
-
+  //  Floating-Point registers write
+  assign fregs_we     = (FPU == 1 & ZFINX == 0) ? ((regfile_alu_we_fw && regfile_alu_waddr_fw[5]) ||
+                                                   (regfile_we_wb     && regfile_waddr_fw_wb_o[5]))
+                                                : 1'b0;
 
   ///////////////////////////
   //   ____  __  __ ____   //

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_cs_registers.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_cs_registers.sv
@@ -68,6 +68,7 @@ module cv32e40p_cs_registers
     output logic [        2:0] frm_o,
     input  logic [C_FFLAG-1:0] fflags_i,
     input  logic               fflags_we_i,
+    input  logic               fregs_we_i,
 
     // Interrupts
     output logic [31:0] mie_bypass_o,
@@ -212,6 +213,7 @@ module cv32e40p_cs_registers
 
   logic [31:0] exception_pc;
   Status_t mstatus_q, mstatus_n;
+  logic mstatus_we_int;
   FS_t mstatus_fs_q, mstatus_fs_n;
   logic [5:0] mcause_q, mcause_n;
   logic [5:0] ucause_q, ucause_n;
@@ -507,7 +509,7 @@ module cv32e40p_cs_registers
 
         // mimpid, Machine Implementation ID
         CSR_MIMPID: begin
-          csr_rdata_int = (FPU || COREV_PULP || COREV_CLUSTER) ? 32'h1 : 'b0;
+          csr_rdata_int = (FPU == 1 || COREV_PULP == 1 || COREV_CLUSTER == 1) ? 32'h1 : 'b0;
         end
 
         // unimplemented, read 0 CSRs
@@ -897,6 +899,7 @@ module cv32e40p_cs_registers
       dscratch0_n = dscratch0_q;
       dscratch1_n = dscratch1_q;
 
+      mstatus_we_int = 1'b0;
       mstatus_n = mstatus_q;
       mcause_n = mcause_q;
       ucause_n = '0;  // Not used if PULP_SECURE == 0
@@ -957,7 +960,8 @@ module cv32e40p_cs_registers
               mprv: csr_wdata_int[MSTATUS_MPRV_BIT]
           };
           if (FPU == 1 && ZFINX == 0) begin
-            mstatus_fs_n = FS_t'(csr_wdata_int[MSTATUS_FS_BIT_HIGH:MSTATUS_FS_BIT_LOW]);
+            mstatus_we_int = 1'b1;
+            mstatus_fs_n   = FS_t'(csr_wdata_int[MSTATUS_FS_BIT_HIGH:MSTATUS_FS_BIT_LOW]);
           end
         end
         // mie: machine interrupt enable
@@ -1027,7 +1031,7 @@ module cv32e40p_cs_registers
 
         if (ZFINX == 0) begin
           // FPU Register File/Flags implicit update or modified by CSR instructions
-          if (fflags_we_i || fcsr_update) begin
+          if ((fregs_we_i && !(mstatus_we_int && mstatus_fs_n != FS_DIRTY)) || fflags_we_i || fcsr_update) begin
             mstatus_fs_n = FS_DIRTY;
           end
         end

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_ex_stage.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_ex_stage.sv
@@ -33,6 +33,7 @@ module cv32e40p_ex_stage
   import cv32e40p_pkg::*;
   import cv32e40p_apu_core_pkg::*;
 #(
+    parameter COREV_PULP       = 0,
     parameter FPU              = 0,
     parameter APU_NARGS_CPU    = 3,
     parameter APU_WOP_CPU      = 6,
@@ -80,6 +81,8 @@ module cv32e40p_ex_stage
     input logic data_rvalid_i,
     input logic data_misaligned_ex_i,
     input logic data_misaligned_i,
+
+    input logic [1:0] ctrl_transfer_insn_in_dec_i,
 
     // FPU signals
     output logic fpu_fflags_we_o,
@@ -138,11 +141,13 @@ module cv32e40p_ex_stage
     // Output of EX stage pipeline
     output logic [ 5:0] regfile_waddr_wb_o,
     output logic        regfile_we_wb_o,
+    output logic        regfile_we_wb_power_o,
     output logic [31:0] regfile_wdata_wb_o,
 
     // Forwarding ports : to ID stage
     output logic [ 5:0] regfile_alu_waddr_fw_o,
     output logic        regfile_alu_we_fw_o,
+    output logic        regfile_alu_we_fw_power_o,
     output logic [31:0] regfile_alu_wdata_fw_o,  // forward to RF and ID/EX pipe, ALU & MUL
 
     // To IF: Jump and branch target and decision
@@ -190,22 +195,27 @@ module cv32e40p_ex_stage
 
   // ALU write port mux
   always_comb begin
-    regfile_alu_wdata_fw_o = '0;
-    regfile_alu_waddr_fw_o = '0;
-    regfile_alu_we_fw_o    = '0;
-    wb_contention          = 1'b0;
+    regfile_alu_wdata_fw_o    = '0;
+    regfile_alu_waddr_fw_o    = '0;
+    regfile_alu_we_fw_o       = 1'b0;
+    regfile_alu_we_fw_power_o = 1'b0;
+    wb_contention             = 1'b0;
 
-    // APU single cycle operations, and multicycle operations (>2cycles) are written back on ALU port
+    // APU single cycle operations, and multicycle operations (> 2cycles) are written back on ALU port
     if (apu_valid & (apu_singlecycle | apu_multicycle)) begin
-      regfile_alu_we_fw_o    = 1'b1;
-      regfile_alu_waddr_fw_o = apu_waddr;
-      regfile_alu_wdata_fw_o = apu_result;
+      regfile_alu_we_fw_o       = 1'b1;
+      regfile_alu_we_fw_power_o = 1'b1;
+      regfile_alu_waddr_fw_o    = apu_waddr;
+      regfile_alu_wdata_fw_o    = apu_result;
 
       if (regfile_alu_we_i & ~apu_en_i) begin
         wb_contention = 1'b1;
       end
     end else begin
-      regfile_alu_we_fw_o    = regfile_alu_we_i & ~apu_en_i;  // private fpu incomplete?
+      regfile_alu_we_fw_o = regfile_alu_we_i & ~apu_en_i;
+      regfile_alu_we_fw_power_o = (COREV_PULP == 0) ? regfile_alu_we_i & ~apu_en_i : 
+                                                     regfile_alu_we_i & ~apu_en_i &
+                                                     mult_ready & alu_ready & lsu_ready_ex_i;
       regfile_alu_waddr_fw_o = regfile_alu_waddr_i;
       if (alu_en_i) regfile_alu_wdata_fw_o = alu_result;
       if (mult_en_i) regfile_alu_wdata_fw_o = mult_result;
@@ -215,21 +225,24 @@ module cv32e40p_ex_stage
 
   // LSU write port mux
   always_comb begin
-    regfile_we_wb_o    = 1'b0;
-    regfile_waddr_wb_o = regfile_waddr_lsu;
-    regfile_wdata_wb_o = lsu_rdata_i;
-    wb_contention_lsu  = 1'b0;
+    regfile_we_wb_o       = 1'b0;
+    regfile_we_wb_power_o = 1'b0;
+    regfile_waddr_wb_o    = regfile_waddr_lsu;
+    regfile_wdata_wb_o    = lsu_rdata_i;
+    wb_contention_lsu     = 1'b0;
 
     if (regfile_we_lsu) begin
-      regfile_we_wb_o = 1'b1;
+      regfile_we_wb_o       = 1'b1;
+      regfile_we_wb_power_o = (COREV_PULP == 0) ? 1'b1 : ~data_misaligned_ex_i & wb_ready_i;
       if (apu_valid & (!apu_singlecycle & !apu_multicycle)) begin
         wb_contention_lsu = 1'b1;
       end
       // APU two-cycle operations are written back on LSU port
     end else if (apu_valid & (!apu_singlecycle & !apu_multicycle)) begin
-      regfile_we_wb_o    = 1'b1;
-      regfile_waddr_wb_o = apu_waddr;
-      regfile_wdata_wb_o = apu_result;
+      regfile_we_wb_o       = 1'b1;
+      regfile_we_wb_power_o = 1'b1;
+      regfile_waddr_wb_o    = apu_waddr;
+      regfile_wdata_wb_o    = apu_result;
     end
   end
 
@@ -371,11 +384,20 @@ module cv32e40p_ex_stage
           apu_result_q <= 'b0;
           apu_flags_q  <= 'b0;
         end else begin
-          if (apu_rvalid_i && apu_multicycle && (data_misaligned_i || data_misaligned_ex_i || (data_req_i && regfile_alu_we_i) || (mulh_active && (mult_operator_i == MUL_H)))) begin
+          if (apu_rvalid_i && apu_multicycle &&
+              (data_misaligned_i || data_misaligned_ex_i ||
+               ((data_req_i || data_rvalid_i) && regfile_alu_we_i) ||
+               (mulh_active && (mult_operator_i == MUL_H)) ||
+               ((ctrl_transfer_insn_in_dec_i == BRANCH_JALR) &&
+                regfile_alu_we_i && ~apu_read_dep_for_jalr_o))) begin
             apu_rvalid_q <= 1'b1;
             apu_result_q <= apu_result_i;
             apu_flags_q  <= apu_flags_i;
-          end else if (apu_rvalid_q && !(data_misaligned_i || data_misaligned_ex_i || ((data_req_i || data_rvalid_i) && regfile_alu_we_i) || (mulh_active && (mult_operator_i == MUL_H)))) begin
+          end else if (apu_rvalid_q && !(data_misaligned_i || data_misaligned_ex_i ||
+                                         ((data_req_i || data_rvalid_i) && regfile_alu_we_i) ||
+                                         (mulh_active && (mult_operator_i == MUL_H)) ||
+                                         ((ctrl_transfer_insn_in_dec_i == BRANCH_JALR) &&
+                                          regfile_alu_we_i && ~apu_read_dep_for_jalr_o))) begin
             apu_rvalid_q <= 1'b0;
           end
         end
@@ -383,7 +405,12 @@ module cv32e40p_ex_stage
 
       assign apu_req_o = apu_req;
       assign apu_gnt = apu_gnt_i;
-      assign apu_valid = (apu_multicycle && (data_misaligned_i || data_misaligned_ex_i || ((data_req_i || data_rvalid_i) && regfile_alu_we_i) || (mulh_active && (mult_operator_i == MUL_H)))) ? 1'b0 : (apu_rvalid_i || apu_rvalid_q);
+      assign apu_valid = (apu_multicycle && (data_misaligned_i || data_misaligned_ex_i ||
+                                             ((data_req_i || data_rvalid_i) && regfile_alu_we_i) ||
+                                             (mulh_active && (mult_operator_i == MUL_H)) ||
+                                             ((ctrl_transfer_insn_in_dec_i == BRANCH_JALR) &&
+                                              regfile_alu_we_i && ~apu_read_dep_for_jalr_o)))
+                         ? 1'b0 : (apu_rvalid_i || apu_rvalid_q);
       assign apu_operands_o = apu_operands_i;
       assign apu_op_o = apu_op_i;
       assign apu_result = apu_rvalid_q ? apu_result_q : apu_result_i;

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_fp_wrapper.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_fp_wrapper.sv
@@ -111,7 +111,7 @@ module cv32e40p_fp_wrapper
       .int_fmt_i     (fpnew_pkg::int_format_e'(fpu_int_fmt)),
       .vectorial_op_i(fpu_vec_op),
       .tag_i         (1'b0),
-      .simd_mask_i   ('b0),
+      .simd_mask_i   (1'b0),
       .in_valid_i    (apu_req_i),
       .in_ready_o    (apu_gnt_o),
       .flush_i       (1'b0),

--- a/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_id_stage.sv
+++ b/hw/vendor/openhwgroup_cv32e40p/rtl/cv32e40p_id_stage.sv
@@ -70,6 +70,7 @@ module cv32e40p_id_stage
     output logic        branch_in_ex_o,
     input  logic        branch_decision_i,
     output logic [31:0] jump_target_o,
+    output logic [ 1:0] ctrl_transfer_insn_in_dec_o,
 
     // IF and ID stage signals
     output logic       clear_instr_valid_o,
@@ -225,10 +226,12 @@ module cv32e40p_id_stage
     // Forward Signals
     input logic [5:0] regfile_waddr_wb_i,
     input logic regfile_we_wb_i,
+    input logic regfile_we_wb_power_i,
     input  logic [31:0] regfile_wdata_wb_i, // From wb_stage: selects data from data memory, ex_stage result and sp rdata
 
     input logic [ 5:0] regfile_alu_waddr_fw_i,
     input logic        regfile_alu_we_fw_i,
+    input logic        regfile_alu_we_fw_power_i,
     input logic [31:0] regfile_alu_wdata_fw_i,
 
     // from ALU
@@ -809,6 +812,9 @@ module cv32e40p_id_stage
             if (ctrl_transfer_target_mux_sel == JT_JALR) begin
               apu_read_regs[0]       = regfile_addr_ra_id;
               apu_read_regs_valid[0] = 1'b1;
+            end else begin
+              apu_read_regs[0]       = regfile_addr_ra_id;
+              apu_read_regs_valid[0] = 1'b0;
             end
           end  // OP_A_CURRPC:
           OP_A_REGA_OR_FWD: begin
@@ -948,12 +954,12 @@ module cv32e40p_id_stage
       // Write port a
       .waddr_a_i(regfile_waddr_wb_i),
       .wdata_a_i(regfile_wdata_wb_i),
-      .we_a_i   (regfile_we_wb_i),
+      .we_a_i   (regfile_we_wb_power_i),
 
       // Write port b
       .waddr_b_i(regfile_alu_waddr_fw_i),
       .wdata_b_i(regfile_alu_wdata_fw_i),
-      .we_b_i   (regfile_alu_we_fw_i)
+      .we_b_i   (regfile_alu_we_fw_power_i)
   );
 
 
@@ -1087,7 +1093,7 @@ module cv32e40p_id_stage
       .debug_wfi_no_sleep_i(debug_wfi_no_sleep),
 
       // jump/branches
-      .ctrl_transfer_insn_in_dec_o   (ctrl_transfer_insn_in_dec),
+      .ctrl_transfer_insn_in_dec_o   (ctrl_transfer_insn_in_dec_o),
       .ctrl_transfer_insn_in_id_o    (ctrl_transfer_insn_in_id),
       .ctrl_transfer_target_mux_sel_o(ctrl_transfer_target_mux_sel),
 
@@ -1187,7 +1193,7 @@ module cv32e40p_id_stage
       // jump/branch control
       .branch_taken_ex_i          (branch_taken_ex),
       .ctrl_transfer_insn_in_id_i (ctrl_transfer_insn_in_id),
-      .ctrl_transfer_insn_in_dec_i(ctrl_transfer_insn_in_dec),
+      .ctrl_transfer_insn_in_dec_i(ctrl_transfer_insn_in_dec_o),
 
       // Interrupt signals
       .irq_wu_ctrl_i     (irq_wu_ctrl),

--- a/hw/vendor/pulp_platform_fpnew.lock.hjson
+++ b/hw/vendor/pulp_platform_fpnew.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/fpnew.git
-    rev: d6e581628f3517a1fb1257507d3214e599f7859d
+    rev: 79e453139072df42c9ec8f697132ba485d74e23d
   }
 }

--- a/hw/vendor/pulp_platform_fpnew.vendor.hjson
+++ b/hw/vendor/pulp_platform_fpnew.vendor.hjson
@@ -7,7 +7,7 @@
 
   upstream: {
     url: "https://github.com/pulp-platform/fpnew.git",
-    rev: "d6e581628f3517a1fb1257507d3214e599f7859d",
+    rev: "79e453139072df42c9ec8f697132ba485d74e23d",
   },
 
   exclude_from_upstream: [

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -303,15 +303,27 @@ endif()
 # Set CMAKE flags
 
 # specify the C standard
-set(COMPILER_LINKER_FLAGS "\
-  -march=${CMAKE_SYSTEM_PROCESSOR} \
-  -w -Os -g  -nostdlib  \
-  -ffunction-sections \
-  -DHOST_BUILD \
-  -D${CRT_TYPE} \
-  -D${CRTO} \
-  -DportasmHANDLE_INTERRUPT=vSystemIrqHandler\
-")
+if(NOT ${PROJECT} MATCHES "coremark")
+  set(COMPILER_LINKER_FLAGS "\
+    -march=${CMAKE_SYSTEM_PROCESSOR} \
+    -w -O2 -g  -nostdlib  \
+    -ffunction-sections \
+    -DHOST_BUILD \
+    -D${CRT_TYPE} \
+    -D${CRTO} \
+    -DportasmHANDLE_INTERRUPT=vSystemIrqHandler\
+  ")
+else()
+  set(COMPILER_LINKER_FLAGS "\
+    -march=${CMAKE_SYSTEM_PROCESSOR} \
+    -w -O3 -g  -nostdlib -falign-functions=16 -funroll-all-loops -falign-jumps=4 -finline-functions -Wall -static -pedantic -DPERFORMANCE_RUN=1 -DITERATIONS=1 -DHAS_STDIO=1 -DHAS_PRINTF=1 \
+    -ffunction-sections \
+    -DHOST_BUILD \
+    -D${CRT_TYPE} \
+    -D${CRTO} \
+    -DportasmHANDLE_INTERRUPT=vSystemIrqHandler\
+  ")
+endif()
 set(CMAKE_C_FLAGS ${COMPILER_LINKER_FLAGS})
 
 if (${COMPILER} MATCHES "clang")

--- a/sw/applications/coremark/core_list_join.c
+++ b/sw/applications/coremark/core_list_join.c
@@ -1,0 +1,612 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include "coremark.h"
+/*
+Topic: Description
+        Benchmark using a linked list.
+
+        Linked list is a common data structure used in many applications.
+
+        For our purposes, this will excercise the memory units of the processor.
+        In particular, usage of the list pointers to find and alter data.
+
+        We are not using Malloc since some platforms do not support this
+library.
+
+        Instead, the memory block being passed in is used to create a list,
+        and the benchmark takes care not to add more items then can be
+        accomodated by the memory block. The porting layer will make sure
+        that we have a valid memory block.
+
+        All operations are done in place, without using any extra memory.
+
+        The list itself contains list pointers and pointers to data items.
+        Data items contain the following:
+
+        idx - An index that captures the initial order of the list.
+        data - Variable data initialized based on the input parameters. The 16b
+are divided as follows: o Upper 8b are backup of original data. o Bit 7
+indicates if the lower 7 bits are to be used as is or calculated. o Bits 0-2
+indicate type of operation to perform to get a 7b value. o Bits 3-6 provide
+input for the operation.
+
+*/
+
+/* local functions */
+
+list_head *core_list_find(list_head *list, list_data *info);
+list_head *core_list_reverse(list_head *list);
+list_head *core_list_remove(list_head *item);
+list_head *core_list_undo_remove(list_head *item_removed,
+                                 list_head *item_modified);
+list_head *core_list_insert_new(list_head * insert_point,
+                                list_data * info,
+                                list_head **memblock,
+                                list_data **datablock,
+                                list_head * memblock_end,
+                                list_data * datablock_end);
+typedef ee_s32 (*list_cmp)(list_data *a, list_data *b, core_results *res);
+list_head *core_list_mergesort(list_head *   list,
+                               list_cmp      cmp,
+                               core_results *res);
+
+ee_s16
+calc_func(ee_s16 *pdata, core_results *res)
+{
+    ee_s16 data = *pdata;
+    ee_s16 retval;
+    ee_u8  optype
+        = (data >> 7)
+          & 1;  /* bit 7 indicates if the function result has been cached */
+    if (optype) /* if cached, use cache */
+        return (data & 0x007f);
+    else
+    {                             /* otherwise calculate and cache the result */
+        ee_s16 flag = data & 0x7; /* bits 0-2 is type of function to perform */
+        ee_s16 dtype
+            = ((data >> 3)
+               & 0xf);       /* bits 3-6 is specific data for the operation */
+        dtype |= dtype << 4; /* replicate the lower 4 bits to get an 8b value */
+        switch (flag)
+        {
+            case 0:
+                if (dtype < 0x22) /* set min period for bit corruption */
+                    dtype = 0x22;
+                retval = core_bench_state(res->size,
+                                          res->memblock[3],
+                                          res->seed1,
+                                          res->seed2,
+                                          dtype,
+                                          res->crc);
+                if (res->crcstate == 0)
+                    res->crcstate = retval;
+                break;
+            case 1:
+                retval = core_bench_matrix(&(res->mat), dtype, res->crc);
+                if (res->crcmatrix == 0)
+                    res->crcmatrix = retval;
+                break;
+            default:
+                retval = data;
+                break;
+        }
+        res->crc = crcu16(retval, res->crc);
+        retval &= 0x007f;
+        *pdata = (data & 0xff00) | 0x0080 | retval; /* cache the result */
+        return retval;
+    }
+}
+/* Function: cmp_complex
+        Compare the data item in a list cell.
+
+        Can be used by mergesort.
+*/
+ee_s32
+cmp_complex(list_data *a, list_data *b, core_results *res)
+{
+    ee_s16 val1 = calc_func(&(a->data16), res);
+    ee_s16 val2 = calc_func(&(b->data16), res);
+    return val1 - val2;
+}
+
+/* Function: cmp_idx
+        Compare the idx item in a list cell, and regen the data.
+
+        Can be used by mergesort.
+*/
+ee_s32
+cmp_idx(list_data *a, list_data *b, core_results *res)
+{
+    if (res == NULL)
+    {
+        a->data16 = (a->data16 & 0xff00) | (0x00ff & (a->data16 >> 8));
+        b->data16 = (b->data16 & 0xff00) | (0x00ff & (b->data16 >> 8));
+    }
+    return a->idx - b->idx;
+}
+
+void
+copy_info(list_data *to, list_data *from)
+{
+    to->data16 = from->data16;
+    to->idx    = from->idx;
+}
+
+/* Benchmark for linked list:
+        - Try to find multiple data items.
+        - List sort
+        - Operate on data from list (crc)
+        - Single remove/reinsert
+        * At the end of this function, the list is back to original state
+*/
+ee_u16
+core_bench_list(core_results *res, ee_s16 finder_idx)
+{
+    ee_u16     retval = 0;
+    ee_u16     found = 0, missed = 0;
+    list_head *list     = res->list;
+    ee_s16     find_num = res->seed3;
+    list_head *this_find;
+    list_head *finder, *remover;
+    list_data  info;
+    ee_s16     i;
+
+    info.idx = finder_idx;
+    /* find <find_num> values in the list, and change the list each time
+     * (reverse and cache if value found) */
+    for (i = 0; i < find_num; i++)
+    {
+        info.data16 = (i & 0xff);
+        this_find   = core_list_find(list, &info);
+        list        = core_list_reverse(list);
+        if (this_find == NULL)
+        {
+            missed++;
+            retval += (list->next->info->data16 >> 8) & 1;
+        }
+        else
+        {
+            found++;
+            if (this_find->info->data16 & 0x1) /* use found value */
+                retval += (this_find->info->data16 >> 9) & 1;
+            /* and cache next item at the head of the list (if any) */
+            if (this_find->next != NULL)
+            {
+                finder          = this_find->next;
+                this_find->next = finder->next;
+                finder->next    = list->next;
+                list->next      = finder;
+            }
+        }
+        if (info.idx >= 0)
+            info.idx++;
+#if CORE_DEBUG
+        ee_printf("List find %d: [%d,%d,%d]\n", i, retval, missed, found);
+#endif
+    }
+    retval += found * 4 - missed;
+    /* sort the list by data content and remove one item*/
+    if (finder_idx > 0)
+        list = core_list_mergesort(list, cmp_complex, res);
+    remover = core_list_remove(list->next);
+    /* CRC data content of list from location of index N forward, and then undo
+     * remove */
+    finder = core_list_find(list, &info);
+    if (!finder)
+        finder = list->next;
+    while (finder)
+    {
+        retval = crc16(list->info->data16, retval);
+        finder = finder->next;
+    }
+#if CORE_DEBUG
+    ee_printf("List sort 1: %04x\n", retval);
+#endif
+    remover = core_list_undo_remove(remover, list->next);
+    /* sort the list by index, in effect returning the list to original state */
+    list = core_list_mergesort(list, cmp_idx, NULL);
+    /* CRC data content of list */
+    finder = list->next;
+    while (finder)
+    {
+        retval = crc16(list->info->data16, retval);
+        finder = finder->next;
+    }
+#if CORE_DEBUG
+    ee_printf("List sort 2: %04x\n", retval);
+#endif
+    return retval;
+}
+/* Function: core_list_init
+        Initialize list with data.
+
+        Parameters:
+        blksize - Size of memory to be initialized.
+        memblock - Pointer to memory block.
+        seed - 	Actual values chosen depend on the seed parameter.
+                The seed parameter MUST be supplied from a source that cannot be
+   determined at compile time
+
+        Returns:
+        Pointer to the head of the list.
+
+*/
+list_head *
+core_list_init(ee_u32 blksize, list_head *memblock, ee_s16 seed)
+{
+    /* calculated pointers for the list */
+    ee_u32 per_item = 16 + sizeof(struct list_data_s);
+    ee_u32 size     = (blksize / per_item)
+                  - 2; /* to accomodate systems with 64b pointers, and make sure
+                          same code is executed, set max list elements */
+    list_head *memblock_end  = memblock + size;
+    list_data *datablock     = (list_data *)(memblock_end);
+    list_data *datablock_end = datablock + size;
+    /* some useful variables */
+    ee_u32     i;
+    list_head *finder, *list = memblock;
+    list_data  info;
+
+    /* create a fake items for the list head and tail */
+    list->next         = NULL;
+    list->info         = datablock;
+    list->info->idx    = 0x0000;
+    list->info->data16 = (ee_s16)0x8080;
+    memblock++;
+    datablock++;
+    info.idx    = 0x7fff;
+    info.data16 = (ee_s16)0xffff;
+    core_list_insert_new(
+        list, &info, &memblock, &datablock, memblock_end, datablock_end);
+
+    /* then insert size items */
+    for (i = 0; i < size; i++)
+    {
+        ee_u16 datpat = ((ee_u16)(seed ^ i) & 0xf);
+        ee_u16 dat
+            = (datpat << 3) | (i & 0x7); /* alternate between algorithms */
+        info.data16 = (dat << 8) | dat;  /* fill the data with actual data and
+                                            upper bits with rebuild value */
+        core_list_insert_new(
+            list, &info, &memblock, &datablock, memblock_end, datablock_end);
+    }
+    /* and now index the list so we know initial seed order of the list */
+    finder = list->next;
+    i      = 1;
+    while (finder->next != NULL)
+    {
+        if (i < size / 5) /* first 20% of the list in order */
+            finder->info->idx = i++;
+        else
+        {
+            ee_u16 pat = (ee_u16)(i++ ^ seed); /* get a pseudo random number */
+            finder->info->idx = 0x3fff
+                                & (((i & 0x07) << 8)
+                                   | pat); /* make sure the mixed items end up
+                                              after the ones in sequence */
+        }
+        finder = finder->next;
+    }
+    list = core_list_mergesort(list, cmp_idx, NULL);
+#if CORE_DEBUG
+    ee_printf("Initialized list:\n");
+    finder = list;
+    while (finder)
+    {
+        ee_printf(
+            "[%04x,%04x]", finder->info->idx, (ee_u16)finder->info->data16);
+        finder = finder->next;
+    }
+    ee_printf("\n");
+#endif
+    return list;
+}
+
+/* Function: core_list_insert
+        Insert an item to the list
+
+        Parameters:
+        insert_point - where to insert the item.
+        info - data for the cell.
+        memblock - pointer for the list header
+        datablock - pointer for the list data
+        memblock_end - end of region for list headers
+        datablock_end - end of region for list data
+
+        Returns:
+        Pointer to new item.
+*/
+list_head *
+core_list_insert_new(list_head * insert_point,
+                     list_data * info,
+                     list_head **memblock,
+                     list_data **datablock,
+                     list_head * memblock_end,
+                     list_data * datablock_end)
+{
+    list_head *newitem;
+
+    if ((*memblock + 1) >= memblock_end)
+        return NULL;
+    if ((*datablock + 1) >= datablock_end)
+        return NULL;
+
+    newitem = *memblock;
+    (*memblock)++;
+    newitem->next      = insert_point->next;
+    insert_point->next = newitem;
+
+    newitem->info = *datablock;
+    (*datablock)++;
+    copy_info(newitem->info, info);
+
+    return newitem;
+}
+
+/* Function: core_list_remove
+        Remove an item from the list.
+
+        Operation:
+        For a singly linked list, remove by copying the data from the next item
+        over to the current cell, and unlinking the next item.
+
+        Note:
+        since there is always a fake item at the end of the list, no need to
+   check for NULL.
+
+        Returns:
+        Removed item.
+*/
+list_head *
+core_list_remove(list_head *item)
+{
+    list_data *tmp;
+    list_head *ret = item->next;
+    /* swap data pointers */
+    tmp        = item->info;
+    item->info = ret->info;
+    ret->info  = tmp;
+    /* and eliminate item */
+    item->next = item->next->next;
+    ret->next  = NULL;
+    return ret;
+}
+
+/* Function: core_list_undo_remove
+        Undo a remove operation.
+
+        Operation:
+        Since we want each iteration of the benchmark to be exactly the same,
+        we need to be able to undo a remove.
+        Link the removed item back into the list, and switch the info items.
+
+        Parameters:
+        item_removed - Return value from the <core_list_remove>
+        item_modified - List item that was modified during <core_list_remove>
+
+        Returns:
+        The item that was linked back to the list.
+
+*/
+list_head *
+core_list_undo_remove(list_head *item_removed, list_head *item_modified)
+{
+    list_data *tmp;
+    /* swap data pointers */
+    tmp                 = item_removed->info;
+    item_removed->info  = item_modified->info;
+    item_modified->info = tmp;
+    /* and insert item */
+    item_removed->next  = item_modified->next;
+    item_modified->next = item_removed;
+    return item_removed;
+}
+
+/* Function: core_list_find
+        Find an item in the list
+
+        Operation:
+        Find an item by idx (if not 0) or specific data value
+
+        Parameters:
+        list - list head
+        info - idx or data to find
+
+        Returns:
+        Found item, or NULL if not found.
+*/
+list_head *
+core_list_find(list_head *list, list_data *info)
+{
+    if (info->idx >= 0)
+    {
+        while (list && (list->info->idx != info->idx))
+            list = list->next;
+        return list;
+    }
+    else
+    {
+        while (list && ((list->info->data16 & 0xff) != info->data16))
+            list = list->next;
+        return list;
+    }
+}
+/* Function: core_list_reverse
+        Reverse a list
+
+        Operation:
+        Rearrange the pointers so the list is reversed.
+
+        Parameters:
+        list - list head
+        info - idx or data to find
+
+        Returns:
+        Found item, or NULL if not found.
+*/
+
+list_head *
+core_list_reverse(list_head *list)
+{
+    list_head *next = NULL, *tmp;
+    while (list)
+    {
+        tmp        = list->next;
+        list->next = next;
+        next       = list;
+        list       = tmp;
+    }
+    return next;
+}
+/* Function: core_list_mergesort
+        Sort the list in place without recursion.
+
+        Description:
+        Use mergesort, as for linked list this is a realistic solution.
+        Also, since this is aimed at embedded, care was taken to use iterative
+   rather then recursive algorithm. The sort can either return the list to
+   original order (by idx) , or use the data item to invoke other other
+   algorithms and change the order of the list.
+
+        Parameters:
+        list - list to be sorted.
+        cmp - cmp function to use
+
+        Returns:
+        New head of the list.
+
+        Note:
+        We have a special header for the list that will always be first,
+        but the algorithm could theoretically modify where the list starts.
+
+ */
+list_head *
+core_list_mergesort(list_head *list, list_cmp cmp, core_results *res)
+{
+    list_head *p, *q, *e, *tail;
+    ee_s32     insize, nmerges, psize, qsize, i;
+
+    insize = 1;
+
+    while (1)
+    {
+        p    = list;
+        list = NULL;
+        tail = NULL;
+
+        nmerges = 0; /* count number of merges we do in this pass */
+
+        while (p)
+        {
+            nmerges++; /* there exists a merge to be done */
+            /* step `insize' places along from p */
+            q     = p;
+            psize = 0;
+            for (i = 0; i < insize; i++)
+            {
+                psize++;
+                q = q->next;
+                if (!q)
+                    break;
+            }
+
+            /* if q hasn't fallen off end, we have two lists to merge */
+            qsize = insize;
+
+            /* now we have two lists; merge them */
+            while (psize > 0 || (qsize > 0 && q))
+            {
+
+                /* decide whether next element of merge comes from p or q */
+                if (psize == 0)
+                {
+                    /* p is empty; e must come from q. */
+                    e = q;
+                    q = q->next;
+                    qsize--;
+                }
+                else if (qsize == 0 || !q)
+                {
+                    /* q is empty; e must come from p. */
+                    e = p;
+                    p = p->next;
+                    psize--;
+                }
+                else if (cmp(p->info, q->info, res) <= 0)
+                {
+                    /* First element of p is lower (or same); e must come from
+                     * p. */
+                    e = p;
+                    p = p->next;
+                    psize--;
+                }
+                else
+                {
+                    /* First element of q is lower; e must come from q. */
+                    e = q;
+                    q = q->next;
+                    qsize--;
+                }
+
+                /* add the next element to the merged list */
+                if (tail)
+                {
+                    tail->next = e;
+                }
+                else
+                {
+                    list = e;
+                }
+                tail = e;
+            }
+
+            /* now p has stepped `insize' places along, and q has too */
+            p = q;
+        }
+
+        tail->next = NULL;
+
+        /* If we have done only one merge, we're finished. */
+        if (nmerges <= 1) /* allow for nmerges==0, the empty list case */
+            return list;
+
+        /* Otherwise repeat, merging lists twice the size */
+        insize *= 2;
+    }
+#if COMPILER_REQUIRES_SORT_RETURN
+    return list;
+#endif
+}

--- a/sw/applications/coremark/core_matrix.c
+++ b/sw/applications/coremark/core_matrix.c
@@ -1,0 +1,376 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include "coremark.h"
+/*
+Topic: Description
+        Matrix manipulation benchmark
+
+        This very simple algorithm forms the basis of many more complex
+algorithms.
+
+        The tight inner loop is the focus of many optimizations (compiler as
+well as hardware based) and is thus relevant for embedded processing.
+
+        The total available data space will be divided to 3 parts:
+        NxN Matrix A - initialized with small values (upper 3/4 of the bits all
+zero). NxN Matrix B - initialized with medium values (upper half of the bits all
+zero). NxN Matrix C - used for the result.
+
+        The actual values for A and B must be derived based on input that is not
+available at compile time.
+*/
+ee_s16 matrix_test(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B, MATDAT val);
+ee_s16 matrix_sum(ee_u32 N, MATRES *C, MATDAT clipval);
+void   matrix_mul_const(ee_u32 N, MATRES *C, MATDAT *A, MATDAT val);
+void   matrix_mul_vect(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B);
+void   matrix_mul_matrix(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B);
+void   matrix_mul_matrix_bitextract(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B);
+void   matrix_add_const(ee_u32 N, MATDAT *A, MATDAT val);
+
+#define matrix_test_next(x)      (x + 1)
+#define matrix_clip(x, y)        ((y) ? (x)&0x0ff : (x)&0x0ffff)
+#define matrix_big(x)            (0xf000 | (x))
+#define bit_extract(x, from, to) (((x) >> (from)) & (~(0xffffffff << (to))))
+
+#if CORE_DEBUG
+void
+printmat(MATDAT *A, ee_u32 N, char *name)
+{
+    ee_u32 i, j;
+    ee_printf("Matrix %s [%dx%d]:\n", name, N, N);
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            if (j != 0)
+                ee_printf(",");
+            ee_printf("%d", A[i * N + j]);
+        }
+        ee_printf("\n");
+    }
+}
+void
+printmatC(MATRES *C, ee_u32 N, char *name)
+{
+    ee_u32 i, j;
+    ee_printf("Matrix %s [%dx%d]:\n", name, N, N);
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            if (j != 0)
+                ee_printf(",");
+            ee_printf("%d", C[i * N + j]);
+        }
+        ee_printf("\n");
+    }
+}
+#endif
+/* Function: core_bench_matrix
+        Benchmark function
+
+        Iterate <matrix_test> N times,
+        changing the matrix values slightly by a constant amount each time.
+*/
+ee_u16
+core_bench_matrix(mat_params *p, ee_s16 seed, ee_u16 crc)
+{
+    ee_u32  N   = p->N;
+    MATRES *C   = p->C;
+    MATDAT *A   = p->A;
+    MATDAT *B   = p->B;
+    MATDAT  val = (MATDAT)seed;
+
+    crc = crc16(matrix_test(N, C, A, B, val), crc);
+
+    return crc;
+}
+
+/* Function: matrix_test
+        Perform matrix manipulation.
+
+        Parameters:
+        N - Dimensions of the matrix.
+        C - memory for result matrix.
+        A - input matrix
+        B - operator matrix (not changed during operations)
+
+        Returns:
+        A CRC value that captures all results calculated in the function.
+        In particular, crc of the value calculated on the result matrix
+        after each step by <matrix_sum>.
+
+        Operation:
+
+        1 - Add a constant value to all elements of a matrix.
+        2 - Multiply a matrix by a constant.
+        3 - Multiply a matrix by a vector.
+        4 - Multiply a matrix by a matrix.
+        5 - Add a constant value to all elements of a matrix.
+
+        After the last step, matrix A is back to original contents.
+*/
+ee_s16
+matrix_test(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B, MATDAT val)
+{
+    ee_u16 crc     = 0;
+    MATDAT clipval = matrix_big(val);
+
+    matrix_add_const(N, A, val); /* make sure data changes  */
+#if CORE_DEBUG
+    printmat(A, N, "matrix_add_const");
+#endif
+    matrix_mul_const(N, C, A, val);
+    crc = crc16(matrix_sum(N, C, clipval), crc);
+#if CORE_DEBUG
+    printmatC(C, N, "matrix_mul_const");
+#endif
+    matrix_mul_vect(N, C, A, B);
+    crc = crc16(matrix_sum(N, C, clipval), crc);
+#if CORE_DEBUG
+    printmatC(C, N, "matrix_mul_vect");
+#endif
+    matrix_mul_matrix(N, C, A, B);
+    crc = crc16(matrix_sum(N, C, clipval), crc);
+#if CORE_DEBUG
+    printmatC(C, N, "matrix_mul_matrix");
+#endif
+    matrix_mul_matrix_bitextract(N, C, A, B);
+    crc = crc16(matrix_sum(N, C, clipval), crc);
+#if CORE_DEBUG
+    printmatC(C, N, "matrix_mul_matrix_bitextract");
+#endif
+
+    matrix_add_const(N, A, -val); /* return matrix to initial value */
+    return crc;
+}
+
+/* Function : matrix_init
+        Initialize the memory block for matrix benchmarking.
+
+        Parameters:
+        blksize - Size of memory to be initialized.
+        memblk - Pointer to memory block.
+        seed - Actual values chosen depend on the seed parameter.
+        p - pointers to <mat_params> containing initialized matrixes.
+
+        Returns:
+        Matrix dimensions.
+
+        Note:
+        The seed parameter MUST be supplied from a source that cannot be
+   determined at compile time
+*/
+ee_u32
+core_init_matrix(ee_u32 blksize, void *memblk, ee_s32 seed, mat_params *p)
+{
+    ee_u32  N = 0;
+    MATDAT *A;
+    MATDAT *B;
+    ee_s32  order = 1;
+    MATDAT  val;
+    ee_u32  i = 0, j = 0;
+    if (seed == 0)
+        seed = 1;
+    while (j < blksize)
+    {
+        i++;
+        j = i * i * 2 * 4;
+    }
+    N = i - 1;
+    A = (MATDAT *)align_mem(memblk);
+    B = A + N * N;
+
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            seed         = ((order * seed) % 65536);
+            val          = (seed + order);
+            val          = matrix_clip(val, 0);
+            B[i * N + j] = val;
+            val          = (val + order);
+            val          = matrix_clip(val, 1);
+            A[i * N + j] = val;
+            order++;
+        }
+    }
+
+    p->A = A;
+    p->B = B;
+    p->C = (MATRES *)align_mem(B + N * N);
+    p->N = N;
+#if CORE_DEBUG
+    printmat(A, N, "A");
+    printmat(B, N, "B");
+#endif
+    return N;
+}
+
+/* Function: matrix_sum
+        Calculate a function that depends on the values of elements in the
+   matrix.
+
+        For each element, accumulate into a temporary variable.
+
+        As long as this value is under the parameter clipval,
+        add 1 to the result if the element is bigger then the previous.
+
+        Otherwise, reset the accumulator and add 10 to the result.
+*/
+ee_s16
+matrix_sum(ee_u32 N, MATRES *C, MATDAT clipval)
+{
+    MATRES tmp = 0, prev = 0, cur = 0;
+    ee_s16 ret = 0;
+    ee_u32 i, j;
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            cur = C[i * N + j];
+            tmp += cur;
+            if (tmp > clipval)
+            {
+                ret += 10;
+                tmp = 0;
+            }
+            else
+            {
+                ret += (cur > prev) ? 1 : 0;
+            }
+            prev = cur;
+        }
+    }
+    return ret;
+}
+
+/* Function: matrix_mul_const
+        Multiply a matrix by a constant.
+        This could be used as a scaler for instance.
+*/
+void
+matrix_mul_const(ee_u32 N, MATRES *C, MATDAT *A, MATDAT val)
+{
+    ee_u32 i, j;
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            C[i * N + j] = (MATRES)A[i * N + j] * (MATRES)val;
+        }
+    }
+}
+
+/* Function: matrix_add_const
+        Add a constant value to all elements of a matrix.
+*/
+void
+matrix_add_const(ee_u32 N, MATDAT *A, MATDAT val)
+{
+    ee_u32 i, j;
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            A[i * N + j] += val;
+        }
+    }
+}
+
+/* Function: matrix_mul_vect
+        Multiply a matrix by a vector.
+        This is common in many simple filters (e.g. fir where a vector of
+   coefficients is applied to the matrix.)
+*/
+void
+matrix_mul_vect(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B)
+{
+    ee_u32 i, j;
+    for (i = 0; i < N; i++)
+    {
+        C[i] = 0;
+        for (j = 0; j < N; j++)
+        {
+            C[i] += (MATRES)A[i * N + j] * (MATRES)B[j];
+        }
+    }
+}
+
+/* Function: matrix_mul_matrix
+        Multiply a matrix by a matrix.
+        Basic code is used in many algorithms, mostly with minor changes such as
+   scaling.
+*/
+void
+matrix_mul_matrix(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B)
+{
+    ee_u32 i, j, k;
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            C[i * N + j] = 0;
+            for (k = 0; k < N; k++)
+            {
+                C[i * N + j] += (MATRES)A[i * N + k] * (MATRES)B[k * N + j];
+            }
+        }
+    }
+}
+
+/* Function: matrix_mul_matrix_bitextract
+        Multiply a matrix by a matrix, and extract some bits from the result.
+        Basic code is used in many algorithms, mostly with minor changes such as
+   scaling.
+*/
+void
+matrix_mul_matrix_bitextract(ee_u32 N, MATRES *C, MATDAT *A, MATDAT *B)
+{
+    ee_u32 i, j, k;
+    for (i = 0; i < N; i++)
+    {
+        for (j = 0; j < N; j++)
+        {
+            C[i * N + j] = 0;
+            for (k = 0; k < N; k++)
+            {
+                MATRES tmp = (MATRES)A[i * N + k] * (MATRES)B[k * N + j];
+                C[i * N + j] += bit_extract(tmp, 2, 4) * bit_extract(tmp, 5, 7);
+            }
+        }
+    }
+}

--- a/sw/applications/coremark/core_portme.c
+++ b/sw/applications/coremark/core_portme.c
@@ -1,0 +1,104 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include "csr.h"
+#include "x-heep.h"
+
+#include "coremark.h"
+
+ee_u32 default_num_contexts = 1;
+
+static CORETIMETYPE start_time_val, stop_time_val;
+
+#if VALIDATION_RUN
+volatile ee_s32 seed1_volatile = 0x3415;
+volatile ee_s32 seed2_volatile = 0x3415;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PERFORMANCE_RUN
+volatile ee_s32 seed1_volatile = 0x0;
+volatile ee_s32 seed2_volatile = 0x0;
+volatile ee_s32 seed3_volatile = 0x66;
+#endif
+#if PROFILE_RUN
+volatile ee_s32 seed1_volatile = 0x8;
+volatile ee_s32 seed2_volatile = 0x8;
+volatile ee_s32 seed3_volatile = 0x8;
+#endif
+volatile ee_s32 seed4_volatile = ITERATIONS;
+volatile ee_s32 seed5_volatile = 0;
+
+void
+portable_init(core_portable *p, int *argc, char *argv[])
+{
+    // Don't need to do anything here atm.
+    (void)p;
+    (void)argc;
+    (void)argv;
+}
+
+void
+portable_fini(core_portable *p)
+{
+    // Don't need to do anything here atm.
+    (void)p;
+}
+
+void
+start_time(void)
+{
+    // Enable mcycle counter and read value
+    CSR_CLEAR_BITS(CSR_REG_MCOUNTINHIBIT, 0x1);
+
+    CSR_READ(CSR_REG_MCYCLE, &start_time_val);
+}
+
+void
+stop_time(void)
+{
+    CSR_READ(CSR_REG_MCYCLE, &stop_time_val);
+}
+
+CORE_TICKS
+get_time(void)
+{
+    return (stop_time_val - start_time_val);
+}
+
+secs_ret
+time_in_secs(CORE_TICKS ticks)
+{
+    return ticks*1E-6;  // Normalized to 1 MHz clock period
+}

--- a/sw/applications/coremark/core_portme.h
+++ b/sw/applications/coremark/core_portme.h
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include <stddef.h>
+#include <stdio.h>
+
+typedef signed short   ee_s16;
+typedef unsigned short ee_u16;
+typedef signed int     ee_s32;
+typedef double         ee_f32;
+typedef unsigned char  ee_u8;
+typedef unsigned int   ee_u32;
+typedef ee_u32         ee_ptr_int;
+typedef size_t         ee_size_t;
+
+typedef ee_u32 CORE_TICKS;
+
+typedef struct CORE_PORTABLE_S
+{
+    ee_u8 portable_id;
+} core_portable;
+
+#ifndef MULTITHREAD
+#define MULTITHREAD 1  // 1 means single-core
+#define USE_PTHREAD 0
+#define USE_FORK    0
+#define USE_SOCKET  0
+#endif
+
+#ifndef COMPILER_VERSION
+#ifdef __GNUC__
+#define COMPILER_VERSION "GCC"__VERSION__
+#else
+#define COMPILER_VERSION "Undefined non-gcc compiler used"
+#endif
+#endif
+
+#ifndef COMPILER_FLAGS
+#define COMPILER_FLAGS FLAGS_STR
+#endif
+
+#ifndef MEM_LOCATION
+#define MEM_LOCATION ""
+#endif
+
+#ifndef SEED_METHOD
+#define SEED_METHOD SEED_VOLATILE
+#endif
+
+#ifndef HAS_PRINTF
+#define HAS_PRINTF 1
+#endif
+
+#define align_mem(x) (void *)(4 + (((ee_ptr_int)(x)-1) & ~3))
+
+#define CORETIMETYPE ee_u32
+
+extern ee_u32 default_num_contexts;
+
+void portable_init(core_portable *p, int *argc, char *argv[]);
+void portable_fini(core_portable *p);

--- a/sw/applications/coremark/core_state.c
+++ b/sw/applications/coremark/core_state.c
@@ -1,0 +1,347 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include "coremark.h"
+/* local functions */
+enum CORE_STATE core_state_transition(ee_u8 **instr, ee_u32 *transition_count);
+
+/*
+Topic: Description
+        Simple state machines like this one are used in many embedded products.
+
+        For more complex state machines, sometimes a state transition table
+implementation is used instead, trading speed of direct coding for ease of
+maintenance.
+
+        Since the main goal of using a state machine in CoreMark is to excercise
+the switch/if behaviour, we are using a small moore machine.
+
+        In particular, this machine tests type of string input,
+        trying to determine whether the input is a number or something else.
+        (see core_state.png).
+*/
+
+/* Function: core_bench_state
+        Benchmark function
+
+        Go over the input twice, once direct, and once after introducing some
+   corruption.
+*/
+ee_u16
+core_bench_state(ee_u32 blksize,
+                 ee_u8 *memblock,
+                 ee_s16 seed1,
+                 ee_s16 seed2,
+                 ee_s16 step,
+                 ee_u16 crc)
+{
+    ee_u32 final_counts[NUM_CORE_STATES];
+    ee_u32 track_counts[NUM_CORE_STATES];
+    ee_u8 *p = memblock;
+    ee_u32 i;
+
+#if CORE_DEBUG
+    ee_printf("State Bench: %d,%d,%d,%04x\n", seed1, seed2, step, crc);
+#endif
+    for (i = 0; i < NUM_CORE_STATES; i++)
+    {
+        final_counts[i] = track_counts[i] = 0;
+    }
+    /* run the state machine over the input */
+    while (*p != 0)
+    {
+        enum CORE_STATE fstate = core_state_transition(&p, track_counts);
+        final_counts[fstate]++;
+#if CORE_DEBUG
+        ee_printf("%d,", fstate);
+    }
+    ee_printf("\n");
+#else
+    }
+#endif
+    p = memblock;
+    while (p < (memblock + blksize))
+    { /* insert some corruption */
+        if (*p != ',')
+            *p ^= (ee_u8)seed1;
+        p += step;
+    }
+    p = memblock;
+    /* run the state machine over the input again */
+    while (*p != 0)
+    {
+        enum CORE_STATE fstate = core_state_transition(&p, track_counts);
+        final_counts[fstate]++;
+#if CORE_DEBUG
+        ee_printf("%d,", fstate);
+    }
+    ee_printf("\n");
+#else
+    }
+#endif
+    p = memblock;
+    while (p < (memblock + blksize))
+    { /* undo corruption is seed1 and seed2 are equal */
+        if (*p != ',')
+            *p ^= (ee_u8)seed2;
+        p += step;
+    }
+    /* end timing */
+    for (i = 0; i < NUM_CORE_STATES; i++)
+    {
+        crc = crcu32(final_counts[i], crc);
+        crc = crcu32(track_counts[i], crc);
+    }
+    return crc;
+}
+
+/* Default initialization patterns */
+static ee_u8 *intpat[4]
+    = { (ee_u8 *)"5012", (ee_u8 *)"1234", (ee_u8 *)"-874", (ee_u8 *)"+122" };
+static ee_u8 *floatpat[4] = { (ee_u8 *)"35.54400",
+                              (ee_u8 *)".1234500",
+                              (ee_u8 *)"-110.700",
+                              (ee_u8 *)"+0.64400" };
+static ee_u8 *scipat[4]   = { (ee_u8 *)"5.500e+3",
+                            (ee_u8 *)"-.123e-2",
+                            (ee_u8 *)"-87e+832",
+                            (ee_u8 *)"+0.6e-12" };
+static ee_u8 *errpat[4]   = { (ee_u8 *)"T0.3e-1F",
+                            (ee_u8 *)"-T.T++Tq",
+                            (ee_u8 *)"1T3.4e4z",
+                            (ee_u8 *)"34.0e-T^" };
+
+/* Function: core_init_state
+        Initialize the input data for the state machine.
+
+        Populate the input with several predetermined strings, interspersed.
+        Actual patterns chosen depend on the seed parameter.
+
+        Note:
+        The seed parameter MUST be supplied from a source that cannot be
+   determined at compile time
+*/
+void
+core_init_state(ee_u32 size, ee_s16 seed, ee_u8 *p)
+{
+    ee_u32 total = 0, next = 0, i;
+    ee_u8 *buf = 0;
+#if CORE_DEBUG
+    ee_u8 *start = p;
+    ee_printf("State: %d,%d\n", size, seed);
+#endif
+    size--;
+    next = 0;
+    while ((total + next + 1) < size)
+    {
+        if (next > 0)
+        {
+            for (i = 0; i < next; i++)
+                *(p + total + i) = buf[i];
+            *(p + total + i) = ',';
+            total += next + 1;
+        }
+        seed++;
+        switch (seed & 0x7)
+        {
+            case 0: /* int */
+            case 1: /* int */
+            case 2: /* int */
+                buf  = intpat[(seed >> 3) & 0x3];
+                next = 4;
+                break;
+            case 3: /* float */
+            case 4: /* float */
+                buf  = floatpat[(seed >> 3) & 0x3];
+                next = 8;
+                break;
+            case 5: /* scientific */
+            case 6: /* scientific */
+                buf  = scipat[(seed >> 3) & 0x3];
+                next = 8;
+                break;
+            case 7: /* invalid */
+                buf  = errpat[(seed >> 3) & 0x3];
+                next = 8;
+                break;
+            default: /* Never happen, just to make some compilers happy */
+                break;
+        }
+    }
+    size++;
+    while (total < size)
+    { /* fill the rest with 0 */
+        *(p + total) = 0;
+        total++;
+    }
+#if CORE_DEBUG
+    ee_printf("State Input: %s\n", start);
+#endif
+}
+
+static ee_u8
+ee_isdigit(ee_u8 c)
+{
+    ee_u8 retval;
+    retval = ((c >= '0') & (c <= '9')) ? 1 : 0;
+    return retval;
+}
+
+/* Function: core_state_transition
+        Actual state machine.
+
+        The state machine will continue scanning until either:
+        1 - an invalid input is detcted.
+        2 - a valid number has been detected.
+
+        The input pointer is updated to point to the end of the token, and the
+   end state is returned (either specific format determined or invalid).
+*/
+
+enum CORE_STATE
+core_state_transition(ee_u8 **instr, ee_u32 *transition_count)
+{
+    ee_u8 *         str = *instr;
+    ee_u8           NEXT_SYMBOL;
+    enum CORE_STATE state = CORE_START;
+    for (; *str && state != CORE_INVALID; str++)
+    {
+        NEXT_SYMBOL = *str;
+        if (NEXT_SYMBOL == ',') /* end of this input */
+        {
+            str++;
+            break;
+        }
+        switch (state)
+        {
+            case CORE_START:
+                if (ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_INT;
+                }
+                else if (NEXT_SYMBOL == '+' || NEXT_SYMBOL == '-')
+                {
+                    state = CORE_S1;
+                }
+                else if (NEXT_SYMBOL == '.')
+                {
+                    state = CORE_FLOAT;
+                }
+                else
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_INVALID]++;
+                }
+                transition_count[CORE_START]++;
+                break;
+            case CORE_S1:
+                if (ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_INT;
+                    transition_count[CORE_S1]++;
+                }
+                else if (NEXT_SYMBOL == '.')
+                {
+                    state = CORE_FLOAT;
+                    transition_count[CORE_S1]++;
+                }
+                else
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_S1]++;
+                }
+                break;
+            case CORE_INT:
+                if (NEXT_SYMBOL == '.')
+                {
+                    state = CORE_FLOAT;
+                    transition_count[CORE_INT]++;
+                }
+                else if (!ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_INT]++;
+                }
+                break;
+            case CORE_FLOAT:
+                if (NEXT_SYMBOL == 'E' || NEXT_SYMBOL == 'e')
+                {
+                    state = CORE_S2;
+                    transition_count[CORE_FLOAT]++;
+                }
+                else if (!ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_FLOAT]++;
+                }
+                break;
+            case CORE_S2:
+                if (NEXT_SYMBOL == '+' || NEXT_SYMBOL == '-')
+                {
+                    state = CORE_EXPONENT;
+                    transition_count[CORE_S2]++;
+                }
+                else
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_S2]++;
+                }
+                break;
+            case CORE_EXPONENT:
+                if (ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_SCIENTIFIC;
+                    transition_count[CORE_EXPONENT]++;
+                }
+                else
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_EXPONENT]++;
+                }
+                break;
+            case CORE_SCIENTIFIC:
+                if (!ee_isdigit(NEXT_SYMBOL))
+                {
+                    state = CORE_INVALID;
+                    transition_count[CORE_INVALID]++;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+    *instr = str;
+    return state;
+}

--- a/sw/applications/coremark/core_util.c
+++ b/sw/applications/coremark/core_util.c
@@ -1,0 +1,266 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+#include "coremark.h"
+/* Function: get_seed
+        Get a values that cannot be determined at compile time.
+
+        Since different embedded systems and compilers are used, 3 different
+   methods are provided: 1 - Using a volatile variable. This method is only
+   valid if the compiler is forced to generate code that reads the value of a
+   volatile variable from memory at run time. Please note, if using this method,
+   you would need to modify core_portme.c to generate training profile. 2 -
+   Command line arguments. This is the preferred method if command line
+   arguments are supported. 3 - System function. If none of the first 2 methods
+   is available on the platform, a system function which is not a stub can be
+   used.
+
+        e.g. read the value on GPIO pins connected to switches, or invoke
+   special simulator functions.
+*/
+#if (SEED_METHOD == SEED_VOLATILE)
+extern volatile ee_s32 seed1_volatile;
+extern volatile ee_s32 seed2_volatile;
+extern volatile ee_s32 seed3_volatile;
+extern volatile ee_s32 seed4_volatile;
+extern volatile ee_s32 seed5_volatile;
+ee_s32
+get_seed_32(int i)
+{
+    ee_s32 retval;
+    switch (i)
+    {
+        case 1:
+            retval = seed1_volatile;
+            break;
+        case 2:
+            retval = seed2_volatile;
+            break;
+        case 3:
+            retval = seed3_volatile;
+            break;
+        case 4:
+            retval = seed4_volatile;
+            break;
+        case 5:
+            retval = seed5_volatile;
+            break;
+        default:
+            retval = 0;
+            break;
+    }
+    return retval;
+}
+#elif (SEED_METHOD == SEED_ARG)
+ee_s32
+parseval(char *valstring)
+{
+    ee_s32 retval  = 0;
+    ee_s32 neg     = 1;
+    int    hexmode = 0;
+    if (*valstring == '-')
+    {
+        neg = -1;
+        valstring++;
+    }
+    if ((valstring[0] == '0') && (valstring[1] == 'x'))
+    {
+        hexmode = 1;
+        valstring += 2;
+    }
+    /* first look for digits */
+    if (hexmode)
+    {
+        while (((*valstring >= '0') && (*valstring <= '9'))
+               || ((*valstring >= 'a') && (*valstring <= 'f')))
+        {
+            ee_s32 digit = *valstring - '0';
+            if (digit > 9)
+                digit = 10 + *valstring - 'a';
+            retval *= 16;
+            retval += digit;
+            valstring++;
+        }
+    }
+    else
+    {
+        while ((*valstring >= '0') && (*valstring <= '9'))
+        {
+            ee_s32 digit = *valstring - '0';
+            retval *= 10;
+            retval += digit;
+            valstring++;
+        }
+    }
+    /* now add qualifiers */
+    if (*valstring == 'K')
+        retval *= 1024;
+    if (*valstring == 'M')
+        retval *= 1024 * 1024;
+
+    retval *= neg;
+    return retval;
+}
+
+ee_s32
+get_seed_args(int i, int argc, char *argv[])
+{
+    if (argc > i)
+        return parseval(argv[i]);
+    return 0;
+}
+
+#elif (SEED_METHOD == SEED_FUNC)
+/* If using OS based function, you must define and implement the functions below
+ * in core_portme.h and core_portme.c ! */
+ee_s32
+get_seed_32(int i)
+{
+    ee_s32 retval;
+    switch (i)
+    {
+        case 1:
+            retval = portme_sys1();
+            break;
+        case 2:
+            retval = portme_sys2();
+            break;
+        case 3:
+            retval = portme_sys3();
+            break;
+        case 4:
+            retval = portme_sys4();
+            break;
+        case 5:
+            retval = portme_sys5();
+            break;
+        default:
+            retval = 0;
+            break;
+    }
+    return retval;
+}
+#endif
+
+/* Function: crc*
+        Service functions to calculate 16b CRC code.
+
+*/
+ee_u16
+crcu8(ee_u8 data, ee_u16 crc)
+{
+    ee_u8 i = 0, x16 = 0, carry = 0;
+
+    for (i = 0; i < 8; i++)
+    {
+        x16 = (ee_u8)((data & 1) ^ ((ee_u8)crc & 1));
+        data >>= 1;
+
+        if (x16 == 1)
+        {
+            crc ^= 0x4002;
+            carry = 1;
+        }
+        else
+            carry = 0;
+        crc >>= 1;
+        if (carry)
+            crc |= 0x8000;
+        else
+            crc &= 0x7fff;
+    }
+    return crc;
+}
+ee_u16
+crcu16(ee_u16 newval, ee_u16 crc)
+{
+    crc = crcu8((ee_u8)(newval), crc);
+    crc = crcu8((ee_u8)((newval) >> 8), crc);
+    return crc;
+}
+ee_u16
+crcu32(ee_u32 newval, ee_u16 crc)
+{
+    crc = crc16((ee_s16)newval, crc);
+    crc = crc16((ee_s16)(newval >> 16), crc);
+    return crc;
+}
+ee_u16
+crc16(ee_s16 newval, ee_u16 crc)
+{
+    return crcu16((ee_u16)newval, crc);
+}
+
+ee_u8
+check_data_types()
+{
+    ee_u8 retval = 0;
+    if (sizeof(ee_u8) != 1)
+    {
+        ee_printf("ERROR: ee_u8 is not an 8b datatype!\n");
+        retval++;
+    }
+    if (sizeof(ee_u16) != 2)
+    {
+        ee_printf("ERROR: ee_u16 is not a 16b datatype!\n");
+        retval++;
+    }
+    if (sizeof(ee_s16) != 2)
+    {
+        ee_printf("ERROR: ee_s16 is not a 16b datatype!\n");
+        retval++;
+    }
+    if (sizeof(ee_s32) != 4)
+    {
+        ee_printf("ERROR: ee_s32 is not a 32b datatype!\n");
+        retval++;
+    }
+    if (sizeof(ee_u32) != 4)
+    {
+        ee_printf("ERROR: ee_u32 is not a 32b datatype!\n");
+        retval++;
+    }
+    if (sizeof(ee_ptr_int) != sizeof(int *))
+    {
+        ee_printf(
+            "ERROR: ee_ptr_int is not a datatype that holds an int pointer!\n");
+        retval++;
+    }
+    if (retval > 0)
+    {
+        ee_printf("ERROR: Please modify the datatypes in core_portme.h!\n");
+    }
+    return retval;
+}

--- a/sw/applications/coremark/coremark.h
+++ b/sw/applications/coremark/coremark.h
@@ -1,0 +1,211 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+/* Topic: Description
+        This file contains  declarations of the various benchmark functions.
+*/
+
+/* Configuration: TOTAL_DATA_SIZE
+        Define total size for data algorithms will operate on
+*/
+#ifndef TOTAL_DATA_SIZE
+#define TOTAL_DATA_SIZE 2 * 1000
+#endif
+
+#define SEED_ARG      0
+#define SEED_FUNC     1
+#define SEED_VOLATILE 2
+
+#define MEM_STATIC 0
+#define MEM_MALLOC 1
+#define MEM_STACK  2
+
+#include "core_portme.h"
+
+#if HAS_STDIO
+#include <stdio.h>
+#endif
+#if HAS_PRINTF
+/* By default, printfs are activated for FPGA and disabled for simulation. */
+#define PRINTF_IN_FPGA  1
+#define PRINTF_IN_SIM   0
+
+#if TARGET_SIM && PRINTF_IN_SIM
+        #define ee_printf(fmt, ...)    printf(fmt, ## __VA_ARGS__)
+#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+    #define ee_printf(fmt, ...)    printf(fmt, ## __VA_ARGS__)
+#else
+    #define ee_printf printf
+#endif
+
+#endif
+
+/* Actual benchmark execution in iterate */
+void *iterate(void *pres);
+
+/* Typedef: secs_ret
+        For machines that have floating point support, get number of seconds as
+   a double. Otherwise an unsigned int.
+*/
+#if HAS_FLOAT
+typedef double secs_ret;
+#else
+typedef ee_u32 secs_ret;
+#endif
+
+#if MAIN_HAS_NORETURN
+#define MAIN_RETURN_VAL
+#define MAIN_RETURN_TYPE void
+#else
+#define MAIN_RETURN_VAL  0
+#define MAIN_RETURN_TYPE int
+#endif
+
+void       start_time(void);
+void       stop_time(void);
+CORE_TICKS get_time(void);
+secs_ret   time_in_secs(CORE_TICKS ticks);
+
+/* Misc useful functions */
+ee_u16 crcu8(ee_u8 data, ee_u16 crc);
+ee_u16 crc16(ee_s16 newval, ee_u16 crc);
+ee_u16 crcu16(ee_u16 newval, ee_u16 crc);
+ee_u16 crcu32(ee_u32 newval, ee_u16 crc);
+ee_u8  check_data_types(void);
+void * portable_malloc(ee_size_t size);
+void   portable_free(void *p);
+ee_s32 parseval(char *valstring);
+
+/* Algorithm IDS */
+#define ID_LIST             (1 << 0)
+#define ID_MATRIX           (1 << 1)
+#define ID_STATE            (1 << 2)
+#define ALL_ALGORITHMS_MASK (ID_LIST | ID_MATRIX | ID_STATE)
+#define NUM_ALGORITHMS      3
+
+/* list data structures */
+typedef struct list_data_s
+{
+    ee_s16 data16;
+    ee_s16 idx;
+} list_data;
+
+typedef struct list_head_s
+{
+    struct list_head_s *next;
+    struct list_data_s *info;
+} list_head;
+
+/*matrix benchmark related stuff */
+#define MATDAT_INT 1
+#if MATDAT_INT
+typedef ee_s16 MATDAT;
+typedef ee_s32 MATRES;
+#else
+typedef ee_f16 MATDAT;
+typedef ee_f32 MATRES;
+#endif
+
+typedef struct MAT_PARAMS_S
+{
+    int     N;
+    MATDAT *A;
+    MATDAT *B;
+    MATRES *C;
+} mat_params;
+
+/* state machine related stuff */
+/* List of all the possible states for the FSM */
+typedef enum CORE_STATE
+{
+    CORE_START = 0,
+    CORE_INVALID,
+    CORE_S1,
+    CORE_S2,
+    CORE_INT,
+    CORE_FLOAT,
+    CORE_EXPONENT,
+    CORE_SCIENTIFIC,
+    NUM_CORE_STATES
+} core_state_e;
+
+/* Helper structure to hold results */
+typedef struct RESULTS_S
+{
+    /* inputs */
+    ee_s16              seed1;       /* Initializing seed */
+    ee_s16              seed2;       /* Initializing seed */
+    ee_s16              seed3;       /* Initializing seed */
+    void *              memblock[4]; /* Pointer to safe memory location */
+    ee_u32              size;        /* Size of the data */
+    ee_u32              iterations;  /* Number of iterations to execute */
+    ee_u32              execs;       /* Bitmask of operations to execute */
+    struct list_head_s *list;
+    mat_params          mat;
+    /* outputs */
+    ee_u16 crc;
+    ee_u16 crclist;
+    ee_u16 crcmatrix;
+    ee_u16 crcstate;
+    ee_s16 err;
+    /* ultithread specific */
+    core_portable port;
+} core_results;
+
+/* Multicore execution handling */
+#if (MULTITHREAD > 1)
+ee_u8 core_start_parallel(core_results *res);
+ee_u8 core_stop_parallel(core_results *res);
+#endif
+
+/* list benchmark functions */
+list_head *core_list_init(ee_u32 blksize, list_head *memblock, ee_s16 seed);
+ee_u16     core_bench_list(core_results *res, ee_s16 finder_idx);
+
+/* state benchmark functions */
+void   core_init_state(ee_u32 size, ee_s16 seed, ee_u8 *p);
+ee_u16 core_bench_state(ee_u32 blksize,
+                        ee_u8 *memblock,
+                        ee_s16 seed1,
+                        ee_s16 seed2,
+                        ee_s16 step,
+                        ee_u16 crc);
+
+/* matrix benchmark functions */
+ee_u32 core_init_matrix(ee_u32      blksize,
+                        void *      memblk,
+                        ee_s32      seed,
+                        mat_params *p);
+ee_u16 core_bench_matrix(mat_params *p, ee_s16 seed, ee_u16 crc);

--- a/sw/applications/coremark/main.c
+++ b/sw/applications/coremark/main.c
@@ -1,0 +1,459 @@
+/*
+Copyright 2018 Embedded Microprocessor Benchmark Consortium (EEMBC)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Original Author: Shay Gal-on
+*/
+
+// Copyright 2020 OpenHW Group
+// Copyright 2020 Silicon Labs, Inc.
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://solderpad.org/licenses/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier:Apache-2.0 WITH SHL-2.0
+
+/* File: core_main.c
+        This file contains the framework to acquire a block of memory, seed
+   initial parameters, tun t he benchmark and report the results.
+*/
+#include "coremark.h"
+
+/* Function: iterate
+        Run the benchmark for a specified number of iterations.
+
+        Operation:
+        For each type of benchmarked algorithm:
+                a - Initialize the data block for the algorithm.
+                b - Execute the algorithm N times.
+
+        Returns:
+        NULL.
+*/
+static ee_u16 list_known_crc[]   = { (ee_u16)0xd4b0,
+                                   (ee_u16)0x3340,
+                                   (ee_u16)0x6a79,
+                                   (ee_u16)0xe714,
+                                   (ee_u16)0xe3c1 };
+static ee_u16 matrix_known_crc[] = { (ee_u16)0xbe52,
+                                     (ee_u16)0x1199,
+                                     (ee_u16)0x5608,
+                                     (ee_u16)0x1fd7,
+                                     (ee_u16)0x0747 };
+static ee_u16 state_known_crc[]  = { (ee_u16)0x5e47,
+                                    (ee_u16)0x39bf,
+                                    (ee_u16)0xe5a4,
+                                    (ee_u16)0x8e3a,
+                                    (ee_u16)0x8d84 };
+void *
+iterate(void *pres)
+{
+    ee_u32        i;
+    ee_u16        crc;
+    core_results *res        = (core_results *)pres;
+    ee_u32        iterations = res->iterations;
+    res->crc                 = 0;
+    res->crclist             = 0;
+    res->crcmatrix           = 0;
+    res->crcstate            = 0;
+
+    for (i = 0; i < iterations; i++)
+    {
+        crc      = core_bench_list(res, 1);
+        res->crc = crcu16(crc, res->crc);
+        crc      = core_bench_list(res, -1);
+        res->crc = crcu16(crc, res->crc);
+        if (i == 0)
+            res->crclist = res->crc;
+    }
+    return NULL;
+}
+
+#if (SEED_METHOD == SEED_ARG)
+ee_s32 get_seed_args(int i, int argc, char *argv[]);
+#define get_seed(x)    (ee_s16) get_seed_args(x, argc, argv)
+#define get_seed_32(x) get_seed_args(x, argc, argv)
+#else /* via function or volatile */
+ee_s32 get_seed_32(int i);
+#define get_seed(x) (ee_s16) get_seed_32(x)
+#endif
+
+#if (MEM_METHOD == MEM_STATIC)
+ee_u8 static_memblk[TOTAL_DATA_SIZE];
+#endif
+char *mem_name[3] = { "Static", "Heap", "Stack" };
+/* Function: main
+        Main entry routine for the benchmark.
+        This function is responsible for the following steps:
+
+        1 - Initialize input seeds from a source that cannot be determined at
+   compile time. 2 - Initialize memory block for use. 3 - Run and time the
+   benchmark. 4 - Report results, testing the validity of the output if the
+   seeds are known.
+
+        Arguments:
+        1 - first seed  : Any value
+        2 - second seed : Must be identical to first for iterations to be
+   identical 3 - third seed  : Any value, should be at least an order of
+   magnitude less then the input size, but bigger then 32. 4 - Iterations  :
+   Special, if set to 0, iterations will be automatically determined such that
+   the benchmark will run between 10 to 100 secs
+
+*/
+
+#if MAIN_HAS_NOARGC
+MAIN_RETURN_TYPE
+main(void)
+{
+    int   argc = 0;
+    char *argv[1];
+#else
+MAIN_RETURN_TYPE
+main(int argc, char *argv[])
+{
+#endif
+    ee_u16       i, j = 0, num_algorithms = 0;
+    ee_s16       known_id = -1, total_errors = 0;
+    ee_u16       seedcrc = 0;
+    CORE_TICKS   total_time;
+    core_results results[MULTITHREAD];
+#if (MEM_METHOD == MEM_STACK)
+    ee_u8 stack_memblock[TOTAL_DATA_SIZE * MULTITHREAD];
+#endif
+    /* first call any initializations needed */
+    portable_init(&(results[0].port), &argc, argv);
+    /* First some checks to make sure benchmark will run ok */
+    if (sizeof(struct list_head_s) > 128)
+    {
+        ee_printf("list_head structure too big for comparable data!\n");
+        return MAIN_RETURN_VAL;
+    }
+    results[0].seed1      = get_seed(1);
+    results[0].seed2      = get_seed(2);
+    results[0].seed3      = get_seed(3);
+    results[0].iterations = get_seed_32(4);
+#if CORE_DEBUG
+    results[0].iterations = 1;
+#endif
+    results[0].execs = get_seed_32(5);
+    if (results[0].execs == 0)
+    { /* if not supplied, execute all algorithms */
+        results[0].execs = ALL_ALGORITHMS_MASK;
+    }
+    /* put in some default values based on one seed only for easy testing */
+    if ((results[0].seed1 == 0) && (results[0].seed2 == 0)
+        && (results[0].seed3 == 0))
+    { /* perfromance run */
+        results[0].seed1 = 0;
+        results[0].seed2 = 0;
+        results[0].seed3 = 0x66;
+    }
+    if ((results[0].seed1 == 1) && (results[0].seed2 == 0)
+        && (results[0].seed3 == 0))
+    { /* validation run */
+        results[0].seed1 = 0x3415;
+        results[0].seed2 = 0x3415;
+        results[0].seed3 = 0x66;
+    }
+#if (MEM_METHOD == MEM_STATIC)
+    results[0].memblock[0] = (void *)static_memblk;
+    results[0].size        = TOTAL_DATA_SIZE;
+    results[0].err         = 0;
+#if (MULTITHREAD > 1)
+#error "Cannot use a static data area with multiple contexts!"
+#endif
+#elif (MEM_METHOD == MEM_MALLOC)
+    for (i = 0; i < MULTITHREAD; i++)
+    {
+        ee_s32 malloc_override = get_seed(7);
+        if (malloc_override != 0)
+            results[i].size = malloc_override;
+        else
+            results[i].size = TOTAL_DATA_SIZE;
+        results[i].memblock[0] = portable_malloc(results[i].size);
+        results[i].seed1       = results[0].seed1;
+        results[i].seed2       = results[0].seed2;
+        results[i].seed3       = results[0].seed3;
+        results[i].err         = 0;
+        results[i].execs       = results[0].execs;
+    }
+#elif (MEM_METHOD == MEM_STACK)
+for (i = 0; i < MULTITHREAD; i++)
+{
+    results[i].memblock[0] = stack_memblock + i * TOTAL_DATA_SIZE;
+    results[i].size        = TOTAL_DATA_SIZE;
+    results[i].seed1       = results[0].seed1;
+    results[i].seed2       = results[0].seed2;
+    results[i].seed3       = results[0].seed3;
+    results[i].err         = 0;
+    results[i].execs       = results[0].execs;
+}
+#else
+#error "Please define a way to initialize a memory block."
+#endif
+    /* Data init */
+    /* Find out how space much we have based on number of algorithms */
+    for (i = 0; i < NUM_ALGORITHMS; i++)
+    {
+        if ((1 << (ee_u32)i) & results[0].execs)
+            num_algorithms++;
+    }
+    for (i = 0; i < MULTITHREAD; i++)
+        results[i].size = results[i].size / num_algorithms;
+    /* Assign pointers */
+    for (i = 0; i < NUM_ALGORITHMS; i++)
+    {
+        ee_u32 ctx;
+        if ((1 << (ee_u32)i) & results[0].execs)
+        {
+            for (ctx = 0; ctx < MULTITHREAD; ctx++)
+                results[ctx].memblock[i + 1]
+                    = (char *)(results[ctx].memblock[0]) + results[0].size * j;
+            j++;
+        }
+    }
+    /* call inits */
+    for (i = 0; i < MULTITHREAD; i++)
+    {
+        if (results[i].execs & ID_LIST)
+        {
+            results[i].list = core_list_init(
+                results[0].size, results[i].memblock[1], results[i].seed1);
+        }
+        if (results[i].execs & ID_MATRIX)
+        {
+            core_init_matrix(results[0].size,
+                             results[i].memblock[2],
+                             (ee_s32)results[i].seed1
+                                 | (((ee_s32)results[i].seed2) << 16),
+                             &(results[i].mat));
+        }
+        if (results[i].execs & ID_STATE)
+        {
+            core_init_state(
+                results[0].size, results[i].seed1, results[i].memblock[3]);
+        }
+    }
+
+    /* automatically determine number of iterations if not set */
+    if (results[0].iterations == 0)
+    {
+        secs_ret secs_passed = 0;
+        ee_u32   divisor;
+        results[0].iterations = 1;
+        while (secs_passed < (secs_ret)1)
+        {
+            results[0].iterations *= 10;
+            start_time();
+            iterate(&results[0]);
+            stop_time();
+            secs_passed = time_in_secs(get_time());
+        }
+        /* now we know it executes for at least 1 sec, set actual run time at
+         * about 10 secs */
+        divisor = (ee_u32)secs_passed;
+        if (divisor == 0) /* some machines cast float to int as 0 since this
+                             conversion is not defined by ANSI, but we know at
+                             least one second passed */
+            divisor = 1;
+        results[0].iterations *= 1 + 10 / divisor;
+    }
+    /* perform actual benchmark */
+    start_time();
+#if (MULTITHREAD > 1)
+    if (default_num_contexts > MULTITHREAD)
+    {
+        default_num_contexts = MULTITHREAD;
+    }
+    for (i = 0; i < default_num_contexts; i++)
+    {
+        results[i].iterations = results[0].iterations;
+        results[i].execs      = results[0].execs;
+        core_start_parallel(&results[i]);
+    }
+    for (i = 0; i < default_num_contexts; i++)
+    {
+        core_stop_parallel(&results[i]);
+    }
+#else
+    iterate(&results[0]);
+#endif
+    stop_time();
+    total_time = get_time();
+    /* get a function of the input to report */
+    seedcrc = crc16(results[0].seed1, seedcrc);
+    seedcrc = crc16(results[0].seed2, seedcrc);
+    seedcrc = crc16(results[0].seed3, seedcrc);
+    seedcrc = crc16(results[0].size, seedcrc);
+
+    switch (seedcrc)
+    {                /* test known output for common seeds */
+        case 0x8a02: /* seed1=0, seed2=0, seed3=0x66, size 2000 per algorithm */
+            known_id = 0;
+            ee_printf("6k performance run parameters for coremark.\n");
+            break;
+        case 0x7b05: /*  seed1=0x3415, seed2=0x3415, seed3=0x66, size 2000 per
+                        algorithm */
+            known_id = 1;
+            ee_printf("6k validation run parameters for coremark.\n");
+            break;
+        case 0x4eaf: /* seed1=0x8, seed2=0x8, seed3=0x8, size 400 per algorithm
+                      */
+            known_id = 2;
+            ee_printf("Profile generation run parameters for coremark.\n");
+            break;
+        case 0xe9f5: /* seed1=0, seed2=0, seed3=0x66, size 666 per algorithm */
+            known_id = 3;
+            ee_printf("2K performance run parameters for coremark.\n");
+            break;
+        case 0x18f2: /*  seed1=0x3415, seed2=0x3415, seed3=0x66, size 666 per
+                        algorithm */
+            known_id = 4;
+            ee_printf("2K validation run parameters for coremark.\n");
+            break;
+        default:
+            total_errors = -1;
+            break;
+    }
+    if (known_id >= 0)
+    {
+        for (i = 0; i < default_num_contexts; i++)
+        {
+            results[i].err = 0;
+            if ((results[i].execs & ID_LIST)
+                && (results[i].crclist != list_known_crc[known_id]))
+            {
+                ee_printf("[%u]ERROR! list crc 0x%04x - should be 0x%04x\n",
+                          i,
+                          results[i].crclist,
+                          list_known_crc[known_id]);
+                results[i].err++;
+            }
+            if ((results[i].execs & ID_MATRIX)
+                && (results[i].crcmatrix != matrix_known_crc[known_id]))
+            {
+                ee_printf("[%u]ERROR! matrix crc 0x%04x - should be 0x%04x\n",
+                          i,
+                          results[i].crcmatrix,
+                          matrix_known_crc[known_id]);
+                results[i].err++;
+            }
+            if ((results[i].execs & ID_STATE)
+                && (results[i].crcstate != state_known_crc[known_id]))
+            {
+                ee_printf("[%u]ERROR! state crc 0x%04x - should be 0x%04x\n",
+                          i,
+                          results[i].crcstate,
+                          state_known_crc[known_id]);
+                results[i].err++;
+            }
+            total_errors += results[i].err;
+        }
+    }
+    total_errors += check_data_types();
+    /* and report results */
+    ee_printf("CoreMark Size    : %lu\n", (long unsigned)results[0].size);
+    ee_printf("Total ticks      : %lu\n", (long unsigned)total_time);
+#if HAS_FLOAT
+    ee_printf("Total time (secs): %f\n", time_in_secs(total_time));
+    if (time_in_secs(total_time) > 0)
+        ee_printf("Iterations/Sec   : %f\n",
+                  default_num_contexts * results[0].iterations
+                      / time_in_secs(total_time));
+#else
+    ee_printf("Total time (secs): %d\n", time_in_secs(total_time));
+    if (time_in_secs(total_time) > 0)
+        ee_printf("Iterations/Sec   : %d\n",
+                  default_num_contexts * results[0].iterations
+                      / time_in_secs(total_time));
+#endif
+/*  if (time_in_secs(total_time) < 10)
+    {
+        ee_printf(
+            "ERROR! Must execute for at least 10 secs for a valid result!\n");
+        total_errors++;
+    }
+*/
+
+    ee_printf("Iterations       : %lu\n",
+              (long unsigned)default_num_contexts * results[0].iterations);
+#if (MULTITHREAD > 1)
+    ee_printf("Parallel %s : %d\n", PARALLEL_METHOD, default_num_contexts);
+#endif
+    ee_printf("Memory location  : %s\n", MEM_LOCATION);
+    /* output for verification */
+    ee_printf("seedcrc          : 0x%04x\n", seedcrc);
+    if (results[0].execs & ID_LIST)
+        for (i = 0; i < default_num_contexts; i++)
+            ee_printf("[%d]crclist       : 0x%04x\n", i, results[i].crclist);
+    if (results[0].execs & ID_MATRIX)
+        for (i = 0; i < default_num_contexts; i++)
+            ee_printf("[%d]crcmatrix     : 0x%04x\n", i, results[i].crcmatrix);
+    if (results[0].execs & ID_STATE)
+        for (i = 0; i < default_num_contexts; i++)
+            ee_printf("[%d]crcstate      : 0x%04x\n", i, results[i].crcstate);
+    for (i = 0; i < default_num_contexts; i++)
+        ee_printf("[%d]crcfinal      : 0x%04x\n", i, results[i].crc);
+    if (total_errors == 0)
+    {
+        ee_printf(
+            "Correct operation validated. See README.md for run and reporting "
+            "rules.\n");
+#if HAS_FLOAT
+        if (known_id == 3)
+        {
+            ee_printf("CoreMark 1.0 : %f / %s",
+                      default_num_contexts * results[0].iterations
+                          / time_in_secs(total_time),
+                      COMPILER_VERSION);
+//                    COMPILER_VERSION,
+//                    COMPILER_FLAGS);
+#if defined(MEM_LOCATION) && !defined(MEM_LOCATION_UNSPEC)
+            ee_printf(" / %s", MEM_LOCATION);
+#else
+            ee_printf(" / %s", mem_name[MEM_METHOD]);
+#endif
+
+#if (MULTITHREAD > 1)
+            ee_printf(" / %d:%s", default_num_contexts, PARALLEL_METHOD);
+#endif
+            ee_printf("\n");
+        }
+#endif
+    }
+    if (total_errors > 0)
+        ee_printf("Errors detected\n");
+    if (total_errors < 0)
+        ee_printf(
+            "Cannot validate operation for these seed values, please compare "
+            "with results on a known platform.\n");
+
+#if (MEM_METHOD == MEM_MALLOC)
+    for (i = 0; i < MULTITHREAD; i++)
+        portable_free(results[i].memblock[0]);
+#endif
+    /* And last call any target specific code for finalizing */
+    portable_fini(&(results[0].port));
+
+    return MAIN_RETURN_VAL;
+}

--- a/sw/applications/example_matadd/main.c
+++ b/sw/applications/example_matadd/main.c
@@ -2,7 +2,6 @@
 // Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "csr.h"

--- a/sw/applications/example_matadd/main.c
+++ b/sw/applications/example_matadd/main.c
@@ -2,6 +2,7 @@
 // Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "csr.h"

--- a/sw/applications/example_matfadd/main.c
+++ b/sw/applications/example_matfadd/main.c
@@ -2,7 +2,6 @@
 // Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
-#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/sw/applications/example_matfadd/main.c
+++ b/sw/applications/example_matfadd/main.c
@@ -2,6 +2,7 @@
 // Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
 // SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
+#include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>

--- a/sw/applications/minver/arch.cfg
+++ b/sw/applications/minver/arch.cfg
@@ -1,0 +1,67 @@
+###############################################################################
+#
+# Copyright 2020 OpenHW Group
+# 
+# Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://solderpad.org/licenses/
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+#
+###############################################################################
+
+# This is a python setting of parameters for the architecture.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.

--- a/sw/applications/minver/beebsc.c
+++ b/sw/applications/minver/beebsc.c
@@ -1,0 +1,177 @@
+/* BEEBS local library variants
+
+   Copyright (C) 2019 Embecosm Limited.
+
+   Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* These are very simple local versions of library routines, to ensure the
+   code is compiled with the flags used for the benchmark.  Not all library
+   routines are here, just ones that cause a lot of unecessary load, or where
+   there is variation between platforms and architectures. */
+
+#include <stddef.h>
+#include <string.h>
+#include "beebsc.h"
+
+/* Seed for the random number generator */
+
+static long int seed = 0;
+
+/* Heap records and sane initial values */
+
+static void *heap_ptr = NULL;
+static void *heap_end = NULL;
+static size_t heap_requested = 0;
+
+
+/* Yield a sequence of random numbers in the range [0, 2^15-1].
+
+   long int is guaranteed to be at least 32 bits. The seed only ever uses 31
+   bits (so is positive).
+
+   For BEEBS this gets round different operating systems using different
+   multipliers and offsets and RAND_MAX variations. */
+
+int
+rand_beebs (void)
+{
+  seed = (seed * 1103515245L + 12345) & ((1UL << 31) - 1);
+  return (int) (seed >> 16);
+}
+
+
+/* Initialize the random number generator */
+
+void
+srand_beebs (unsigned int new_seed)
+{
+  seed = (long int) new_seed;
+}
+
+
+/* Initialize the BEEBS heap pointers. Note that the actual memory block is
+   in the caller code. */
+
+void
+init_heap_beebs (void *heap, size_t heap_size)
+{
+  heap_ptr = (void *) heap;
+  heap_end = (void *) ((char *) heap_ptr + heap_size);
+  heap_requested = 0;
+}
+
+
+/* Report if malloc ever failed.
+
+   Return non-zero (TRUE) if malloc did not reqest more than was available
+   since the last call to init_heap_beebs, zero (FALSE) otherwise. */
+
+int
+check_heap_beebs (void *heap)
+{
+  return ((void *) ((char *) heap + heap_requested) <= heap_end);
+}
+
+
+/* BEEBS version of malloc.
+
+   This is primarily to reduce library and OS dependencies. Malloc is
+   generally not used in embedded code, or if it is, only in well defined
+   contexts to pre-allocate a fixed amount of memory. So this simplistic
+   implementation is just fine.
+
+   Note in particular the assumption that memory will never be freed! */
+
+void *
+malloc_beebs (size_t size)
+{
+  void *new_ptr = heap_ptr;
+
+  heap_requested += size;
+
+  if (((void *) ((char *) heap_ptr + size) > heap_end) || (0 == size))
+    return NULL;
+  else
+    {
+      heap_ptr = (void *) ((char *) heap_ptr + size);
+      return new_ptr;
+    }
+}
+
+
+/* BEEBS version of calloc.
+
+   Implement as wrapper for malloc */
+
+void *
+calloc_beebs (size_t nmemb, size_t size)
+{
+  void *new_ptr = malloc_beebs (nmemb * size);
+
+  /* Calloc is defined to zero the memory. OK to use a function here, because
+     it will be handled specially by the compiler anyway. */
+
+  if (NULL != new_ptr)
+    memset (new_ptr, 0, nmemb * size);
+
+  return new_ptr;
+}
+
+
+/* BEEBS version of realloc.
+
+   This is primarily to reduce library and OS dependencies. We just have to
+   allocate new memory and copy stuff across. */
+
+void *
+realloc_beebs (void *ptr, size_t size)
+{
+  void *new_ptr = heap_ptr;
+
+  heap_requested += size;
+
+  if (((void *) ((char *) heap_ptr + size) > heap_end) || (0 == size))
+    return NULL;
+  else
+    {
+      heap_ptr = (void *) ((char *) heap_ptr + size);
+
+      /* This is clunky, since we don't know the size of the original
+         pointer. However it is a read only action and we know it must
+         be big enough if we right off the end, or we couldn't have
+         allocated here. If the size is smaller, it doesn't matter. */
+
+      if (NULL != ptr)
+	{
+	  size_t i;
+
+	  for (i = 0; i < size; i++)
+	    ((char *) new_ptr)[i] = ((char *) ptr)[i];
+	}
+
+      return new_ptr;
+    }
+}
+
+
+/* BEEBS version of free.
+
+   For our simplified version of memory handling, free can just do nothing. */
+
+void
+free_beebs (void *ptr __attribute__ ((unused)))
+{
+}
+
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/beebsc.h
+++ b/sw/applications/minver/beebsc.h
@@ -1,0 +1,65 @@
+/* BEEBS local library variants header
+
+   Copyright (C) 2019 Embecosm Limited.
+
+   Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef BEEBSC_H
+#define BEEBSC_H
+
+#include <stddef.h>
+
+/* BEEBS fixes RAND_MAX to its lowest permitted value, 2^15-1 */
+
+#ifdef RAND_MAX
+#undef RAND_MAX
+#endif
+#define RAND_MAX ((1U << 15) - 1)
+
+/* Common understanding of a "small value" (epsilon) for floating point
+   comparisons. */
+
+#define VERIFY_DOUBLE_EPS 1.0e-13
+#define VERIFY_FLOAT_EPS 1.0e-5
+
+/* Simplified assert.
+
+   The full complexity of assert is not needed for a benchmark. See the
+   discussion at:
+
+   https://lists.librecores.org/pipermail/embench/2019-August/000007.html 
+
+   This function just*/
+
+#define assert_beebs(expr) { if (!(expr)) exit (1); }
+
+#define float_eq_beebs(exp, actual) (fabsf(exp - actual) < VERIFY_FLOAT_EPS)
+#define float_neq_beebs(exp, actual) !float_eq_beebs(exp, actual)
+#define double_eq_beebs(exp, actual) (fabs(exp - actual) < VERIFY_DOUBLE_EPS)
+#define double_neq_beebs(exp, actual) !double_eq_beebs(exp, actual)
+
+/* Local simplified versions of library functions */
+
+int rand_beebs (void);
+void srand_beebs (unsigned int new_seed);
+
+void init_heap_beebs (void *heap, const size_t heap_size);
+int check_heap_beebs (void *heap);
+void *malloc_beebs (size_t size);
+void *calloc_beebs (size_t nmemb, size_t size);
+void *realloc_beebs (void *ptr, size_t size);
+void free_beebs (void *ptr);
+#endif /* BEEBSC_H */
+
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/board.c
+++ b/sw/applications/minver/board.c
@@ -1,0 +1,22 @@
+/* Common board.c for the benchmarks
+
+   Copyright (C) 2018-2019 Embecosm Limited
+
+   Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* This is just a wrapper for the board specific support file. */
+
+#include "boardsupport.c"
+
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/boardsupport.c
+++ b/sw/applications/minver/boardsupport.c
@@ -1,0 +1,21 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#include "boardsupport.h"
+

--- a/sw/applications/minver/boardsupport.h
+++ b/sw/applications/minver/boardsupport.h
@@ -1,0 +1,21 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+
+

--- a/sw/applications/minver/chip.c
+++ b/sw/applications/minver/chip.c
@@ -1,0 +1,32 @@
+/* Common board.c for the benchmarks
+
+   Copyright (C) 2018-2019 Embecosm Limited
+
+   Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+/* This is just a wrapper for the chip specific support file if there is one. */
+
+/*#include "config.h"*/
+
+#ifdef HAVE_CHIPSUPPORT_H
+#include "chipsupport.c"
+#endif
+
+/* Standard C does not permit empty translation units, so provide one. */
+
+static void
+empty_func ()
+{
+}
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/chipsupport.c
+++ b/sw/applications/minver/chipsupport.c
@@ -1,0 +1,73 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#include <support.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "chipsupport.h"
+
+#include "csr.h"
+#include "x-heep.h"
+
+/* By default, printfs are activated for FPGA and disabled for simulation. */
+#define PRINTF_IN_FPGA  1
+#define PRINTF_IN_SIM   0
+
+#if TARGET_SIM && PRINTF_IN_SIM
+        #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
+#elif TARGET_PYNQ_Z2 && PRINTF_IN_FPGA
+    #define PRINTF(fmt, ...)    printf(fmt, ## __VA_ARGS__)
+#else
+    #define PRINTF(...)
+#endif
+
+#define FS_INITIAL 0x01
+
+void
+initialise_board ()
+{
+  PRINTF("Initialize board corev32 \n");
+
+  //enable FP operations
+  CSR_SET_BITS(CSR_REG_MSTATUS, (FS_INITIAL << 13));
+
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+  PRINTF("start of test \n");
+
+  // Enable mcycle counter and read value
+  CSR_CLEAR_BITS(CSR_REG_MCOUNTINHIBIT, 0x1);
+  CSR_WRITE(CSR_REG_MCYCLE, 0);
+
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+  uint32_t cycle_cnt;
+  CSR_READ(CSR_REG_MCYCLE, &cycle_cnt);
+  PRINTF("end of test \n");
+  PRINTF("Result is given in CPU cycles \n");
+  PRINTF("RES: %d \n", cycle_cnt);
+
+}
+ 

--- a/sw/applications/minver/chipsupport.h
+++ b/sw/applications/minver/chipsupport.h
@@ -1,0 +1,25 @@
+/*
+**
+** Copyright 2020 OpenHW Group
+** 
+** Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+** 
+**     https://solderpad.org/licenses/
+** 
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+** 
+*******************************************************************************
+*/
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+#define CPU_MHZ 1
+
+#endif

--- a/sw/applications/minver/libminver.c
+++ b/sw/applications/minver/libminver.c
@@ -1,0 +1,292 @@
+/* BEEBS minver benchmark
+
+   This version, copyright (C) 2014-2019 Embecosm Limited and University of
+   Bristol
+
+   Contributor Pierre Langlois <pierre.langlois@embecosm.com>
+   Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+
+   *************************************************************************
+   *                                                                       *
+   *   SNU-RT Benchmark Suite for Worst Case Timing Analysis               *
+   *   =====================================================               *
+   *                              Collected and Modified by S.-S. Lim      *
+   *                                           sslim@archi.snu.ac.kr       *
+   *                                         Real-Time Research Group      *
+   *                                        Seoul National University      *
+   *                                                                       *
+   *                                                                       *
+   *        < Features > - restrictions for our experimental environment   *
+   *                                                                       *
+   *          1. Completely structured.                                    *
+   *               - There are no unconditional jumps.                     *
+   *               - There are no exit from loop bodies.                   *
+   *                 (There are no 'break' or 'return' in loop bodies)     *
+   *          2. No 'switch' statements.                                   *
+   *          3. No 'do..while' statements.                                *
+   *          4. Expressions are restricted.                               *
+   *               - There are no multiple expressions joined by 'or',     *
+   *                'and' operations.                                      *
+   *          5. No library calls.                                         *
+   *               - All the functions needed are implemented in the       *
+   *                 source file.                                          *
+   *                                                                       *
+   *                                                                       *
+   *************************************************************************
+   *                                                                       *
+   *  FILE: minver.c                                                       *
+   *  SOURCE : Turbo C Programming for Engineering by Hyun Soo Ahn         *
+   *                                                                       *
+   *  DESCRIPTION :                                                        *
+   *                                                                       *
+   *     Matrix inversion for 3x3 floating point matrix.                   *
+   *                                                                       *
+   *  REMARK :                                                             *
+   *                                                                       *
+   *  EXECUTION TIME :                                                     *
+   *                                                                       *
+   *                                                                       *
+   *************************************************************************
+
+*/
+
+#include <math.h>
+#include <string.h>
+#include "support.h"
+
+/* This scale factor will be changed to equalise the runtime of the
+   benchmarks. */
+#define LOCAL_SCALE_FACTOR 555
+
+int minver (int row, int col, float eps);
+int mmul (int row_a, int col_a, int row_b, int col_b);
+
+static float a_ref[3][3] = {
+  {3.0, -6.0, 7.0},
+  {9.0, 0.0, -5.0},
+  {5.0, -8.0, 6.0},
+};
+
+static float b[3][3] = {
+  {-3.0, 0.0, 2.0},
+  {3.0, -2.0, 0.0},
+  {0.0, 2.0, -3.0},
+};
+
+static float a[3][3], c[3][3], d[3][3], det;
+
+static float
+minver_fabs (float n)
+{
+  float f;
+
+  if (n >= 0)
+    f = n;
+  else
+    f = -n;
+  return f;
+}
+
+int
+mmul (int row_a, int col_a, int row_b, int col_b)
+{
+  int i, j, k, row_c, col_c;
+  float w;
+
+  row_c = row_a;
+  col_c = col_b;
+
+  if (row_c < 1 || row_b < 1 || col_c < 1 || col_a != row_b)
+    return (999);
+  for (i = 0; i < row_c; i++)
+    {
+      for (j = 0; j < col_c; j++)
+	{
+	  w = 0.0;
+	  for (k = 0; k < row_b; k++)
+	    w += a[i][k] * b[k][j];
+	  c[i][j] = w;
+	}
+    }
+
+  return (0);
+}
+
+
+int
+minver (int row, int col, float eps)
+{
+  int work[500], i, j, k, r, iw, u, v;
+  float w, wmax, pivot, api, w1;
+
+  r = w = 0;
+  if (row < 2 || row > 500 || eps <= 0.0)
+    return (999);
+  w1 = 1.0;
+  for (i = 0; i < row; i++)
+    work[i] = i;
+  for (k = 0; k < row; k++)
+    {
+      wmax = 0.0;
+      for (i = k; i < row; i++)
+	{
+	  w = minver_fabs (a[i][k]);
+	  if (w > wmax)
+	    {
+	      wmax = w;
+	      r = i;
+	    }
+	}
+      pivot = a[r][k];
+      api = minver_fabs (pivot);
+      if (api <= eps)
+	{
+	  det = w1;
+	  return (1);
+	}
+      w1 *= pivot;
+      u = k * col;
+      v = r * col;
+      if (r != k)
+	{
+	  w1 = -w;
+	  iw = work[k];
+	  work[k] = work[r];
+	  work[r] = iw;
+	  for (j = 0; j < row; j++)
+	    {
+	      w = a[k][j];
+	      a[k][j] = a[r][j];
+	      a[r][j] = w;
+	    }
+	}
+      for (i = 0; i < row; i++)
+	a[k][i] /= pivot;
+      for (i = 0; i < row; i++)
+	{
+	  if (i != k)
+	    {
+	      v = i * col;
+	      w = a[i][k];
+	      if (w != 0.0)
+		{
+		  for (j = 0; j < row; j++)
+		    if (j != k)
+		      a[i][j] -= w * a[k][j];
+		  a[i][k] = -w / pivot;
+		}
+	    }
+	}
+      a[k][k] = 1.0 / pivot;
+    }
+
+  for (i = 0; i < row; i++)
+    {
+      while (1)
+	{
+	  k = work[i];
+	  if (k == i)
+	    break;
+	  iw = work[k];
+	  work[k] = work[i];
+	  work[i] = iw;
+	  for (j = 0; j < row; j++)
+	    {
+	      u = j * col;
+	      w = a[k][i];
+	      a[k][i] = a[k][k];
+	      a[k][k] = w;
+	    }
+	}
+    }
+
+  det = w1;
+
+  return (0);
+}
+
+
+int
+verify_benchmark (int res __attribute ((unused)))
+{
+  int i, j;
+  float eps = 1.0e-6;
+
+  static float c_exp[3][3] = {
+    {-27.0, 26.0, -15.0},
+    {-27.0, -10.0, 33.0},
+    {-39.0, 28.0, -8.0}
+  };
+
+  static float d_exp[3][3] = {
+    {0.133333325, -0.199999958, 0.2666665910},
+    {-0.519999862, 0.113333330, 0.5266665220},
+    {0.479999840, -0.359999895, 0.0399999917}
+  };
+
+  /* Allow small errors in floating point */
+
+  for (i = 0; i < 3; i++)
+    for (j = 0; j < 3; j++)
+      if (float_neq_beebs(c[i][j], c_exp[i][j]) || float_neq_beebs(d[i][j], d_exp[i][j]))
+	return 0;
+
+  return float_eq_beebs(det, -16.6666718);
+}
+
+
+void
+initialise_benchmark (void)
+{
+}
+
+
+static int benchmark_body (int  rpt);
+
+void
+warm_caches (int  heat)
+{
+  int  res = benchmark_body (heat);
+
+  return;
+}
+
+
+int
+benchmark (void)
+{
+  return benchmark_body (LOCAL_SCALE_FACTOR * 1);
+}
+
+
+static int __attribute__ ((noinline))
+benchmark_body (int rpt)
+{
+  int i;
+
+  for (i = 0; i < rpt; i++)
+    {
+      float eps = 1.0e-6;
+
+      memcpy (a, a_ref, 3 * 3 * sizeof (a[0][0]));
+      minver (3, 3, eps);
+      memcpy (d, a, 3 * 3 * sizeof (a[0][0]));
+      memcpy (a, a_ref, 3 * 3 * sizeof (a[0][0]));
+      mmul (3, 3, 3, 3);
+    }
+
+  return 0;
+}
+
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/main.c
+++ b/sw/applications/minver/main.c
@@ -1,0 +1,50 @@
+/* Common main.c for the benchmarks
+
+   Copyright (C) 2014 Embecosm Limited and University of Bristol
+   Copyright (C) 2018-2019 Embecosm Limited
+
+   Contributor: James Pallister <james.pallister@bristol.ac.uk>
+   Contributor: Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "csr.h"
+#include "x-heep.h"
+
+#include "support.h"
+
+
+int __attribute__ ((used))
+main (int argc __attribute__ ((unused)),
+      char *argv[] __attribute__ ((unused)))
+{
+  int i;
+  volatile int result;
+  int correct;
+
+  initialise_board ();
+  initialise_benchmark ();
+  warm_caches (1);
+
+  start_trigger ();
+  result = benchmark ();
+  stop_trigger ();
+
+  /* bmarks that use arrays will check a global array rather than int result */
+
+  correct = verify_benchmark (result);
+
+  return (!correct);
+
+}				/* main () */
+
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/applications/minver/support.h
+++ b/sw/applications/minver/support.h
@@ -1,0 +1,72 @@
+/* Support header for BEEBS.
+
+   Copyright (C) 2014 Embecosm Limited and the University of Bristol
+   Copyright (C) 2019 Embecosm Limited
+
+   Contributor James Pallister <james.pallister@bristol.ac.uk>
+
+   Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef SUPPORT_H
+#define SUPPORT_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+/* Include board support header if we have one */
+
+#ifdef HAVE_BOARDSUPPORT_H
+#include "boardsupport.h"
+#endif
+
+/* Benchmarks must implement verify_benchmark, which must return -1 if no
+   verification is done. */
+
+int verify_benchmark (int result);
+
+/* Standard functions implemented for each board */
+
+void initialise_board (void);
+void start_trigger (void);
+void stop_trigger (void);
+
+/* Every benchmark implements this for one-off data initialization.  This is
+   only used for initialization that is independent of how often benchmark ()
+   is called. */
+
+void initialise_benchmark (void);
+
+/* Every benchmark implements this for cache warm up, typically calling
+   benchmark several times. The argument controls how much warming up is
+   done, with 0 meaning no warming. */
+
+void warm_caches (int temperature);
+
+/* Every benchmark implements this as its entry point. Don't allow it to be
+   inlined! */
+
+int benchmark (void) __attribute__ ((noinline));
+
+/* Every benchmark must implement this to validate the result of the
+   benchmark. */
+
+int verify_benchmark (int res);
+
+/* Local simplified versions of library functions */
+
+#include "beebsc.h"
+
+#endif /* SUPPORT_H */
+
+/*
+   Local Variables:
+   mode: C
+   c-file-style: "gnu"
+   End:
+*/

--- a/sw/device/bsp/w25q/w25q.c
+++ b/sw/device/bsp/w25q/w25q.c
@@ -29,6 +29,8 @@
 /*                             MODULES USED                                 */
 /**                                                                        **/
 /****************************************************************************/
+#include "string.h"
+
 #include "w25q128jw.h"
 
 /* To manage addresses. */
@@ -887,7 +889,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void *data,
 
 }
 
-void w25q128jw_4k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_4k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > MAX_FLASH_ADDR || addr < 0) return FLASH_ERROR;
 
@@ -914,7 +916,7 @@ void w25q128jw_4k_erase(uint32_t addr) {
     flash_wait();
 }
 
-void w25q128jw_32k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_32k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > 0x00ffffff || addr < 0) return FLASH_ERROR;
 
@@ -941,7 +943,7 @@ void w25q128jw_32k_erase(uint32_t addr) {
     flash_wait();
 }
 
-void w25q128jw_64k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_64k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > 0x00ffffff || addr < 0) return FLASH_ERROR;
 
@@ -1173,7 +1175,7 @@ static void flash_wait(void) {
         spi_set_command(&spi, spi_status_read_cmd);
         spi_wait_for_ready(&spi);
         spi_wait_for_rx_watermark(&spi);
-        spi_read_word(&spi, &flash_resp[0]);
+        spi_read_word(&spi, (uint32_t *)flash_resp);
         if ((flash_resp[0] & 0x01) == 0) flash_busy = false;
     }
 }

--- a/sw/device/bsp/w25q/w25q.c
+++ b/sw/device/bsp/w25q/w25q.c
@@ -54,6 +54,9 @@
 /* For word swap operations*/
 #include "bitfield.h"
 
+/* for memcpy */
+#include <string.h>
+
 /****************************************************************************/
 /**                                                                        **/
 /*                        DEFINITIONS AND MACROS                            */
@@ -887,7 +890,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void *data,
 
 }
 
-void w25q128jw_4k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_4k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > MAX_FLASH_ADDR || addr < 0) return FLASH_ERROR;
 
@@ -912,9 +915,11 @@ void w25q128jw_4k_erase(uint32_t addr) {
 
     // Wait for the erase operation to be finished
     flash_wait();
+
+    return FLASH_OK;
 }
 
-void w25q128jw_32k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_32k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > 0x00ffffff || addr < 0) return FLASH_ERROR;
 
@@ -939,9 +944,11 @@ void w25q128jw_32k_erase(uint32_t addr) {
 
     // Wait for the erase operation to be finished
     flash_wait();
+
+    return FLASH_OK;
 }
 
-void w25q128jw_64k_erase(uint32_t addr) {
+w25q_error_codes_t w25q128jw_64k_erase(uint32_t addr) {
     // Sanity checks
     if (addr > 0x00ffffff || addr < 0) return FLASH_ERROR;
 
@@ -966,6 +973,8 @@ void w25q128jw_64k_erase(uint32_t addr) {
 
     // Wait for the erase operation to be finished
     flash_wait();
+
+    return FLASH_OK;
 }
 
 void w25q128jw_chip_erase(void) {
@@ -1173,7 +1182,7 @@ static void flash_wait(void) {
         spi_set_command(&spi, spi_status_read_cmd);
         spi_wait_for_ready(&spi);
         spi_wait_for_rx_watermark(&spi);
-        spi_read_word(&spi, &flash_resp[0]);
+        spi_read_word(&spi, (uint32_t*)&flash_resp[0]);
         if ((flash_resp[0] & 0x01) == 0) flash_busy = false;
     }
 }

--- a/sw/device/bsp/w25q/w25q128jw.h
+++ b/sw/device/bsp/w25q/w25q128jw.h
@@ -357,7 +357,7 @@ w25q_error_codes_t w25q128jw_erase_and_write_quad_dma(uint32_t addr, void* data,
  *
  * @param addr 24-bit address of the sector to erase.
 */
-void w25q128jw_4k_erase(uint32_t addr);
+w25q_error_codes_t w25q128jw_4k_erase(uint32_t addr);
 
 /**
  * @brief Erase a 32kb block.
@@ -367,7 +367,7 @@ void w25q128jw_4k_erase(uint32_t addr);
  *
  * @param addr 24-bit address of the block to erase.
 */
-void w25q128jw_32k_erase(uint32_t addr);
+w25q_error_codes_t w25q128jw_32k_erase(uint32_t addr);
 
 /**
  * @brief Erase a 64kb block.
@@ -377,7 +377,7 @@ void w25q128jw_32k_erase(uint32_t addr);
  *
  * @param addr 24-bit address of the block to erase.
 */
-void w25q128jw_64k_erase(uint32_t addr);
+w25q_error_codes_t w25q128jw_64k_erase(uint32_t addr);
 
 /**
  * @brief Erase the entire chip.

--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -562,7 +562,7 @@ dma_config_flags_t dma_validate_transaction(    dma_trans_t        *p_trans,
          * No further operations are done to prevent corrupting information
          * that could be useful for debugging purposes.
          */
-        uint8_t isEnv = p_trans->dst->env;
+        uint8_t isEnv = (p_trans->dst->env != NULL);
         uint8_t isOutb = is_region_outbound(
                                     p_trans->dst->ptr,
                                     p_trans->dst->env->end,
@@ -689,7 +689,7 @@ dma_config_flags_t dma_load_transaction( dma_trans_t *p_trans )
     /*
      * SET THE POINTERS
      */
-    dma_cb.peri->SRC_PTR = dma_cb.trans->src->ptr;
+    dma_cb.peri->SRC_PTR = (uint32_t)dma_cb.trans->src->ptr;
 
     if(dma_cb.trans->mode != DMA_TRANS_MODE_ADDRESS)
     {
@@ -698,11 +698,11 @@ dma_config_flags_t dma_load_transaction( dma_trans_t *p_trans )
         otherwise the destination address is read in a separate port in parallel with the data
         from the address port
         */
-        dma_cb.peri->DST_PTR = dma_cb.trans->dst->ptr;
+        dma_cb.peri->DST_PTR = (uint32_t)dma_cb.trans->dst->ptr;
     }
     else
     {
-        dma_cb.peri->ADDR_PTR = dma_cb.trans->src_addr->ptr;
+        dma_cb.peri->ADDR_PTR = (uint32_t)dma_cb.trans->src_addr->ptr;
     }
 
     /*
@@ -1093,7 +1093,7 @@ static inline uint8_t is_region_outbound(   uint8_t  *p_start,
    */
     uint32_t affectedUnits      = ( p_size_du - 1 ) * p_inc_du + 1;
     uint32_t rangeSize          = DMA_DATA_TYPE_2_SIZE(p_type) * affectedUnits;
-    uint32_t lasByteInsideRange = p_start + rangeSize -1;
+    uint32_t lasByteInsideRange = (uint32_t)p_start + rangeSize -1;
     return ( p_end < lasByteInsideRange );
     // Size is be guaranteed to be non-zero before calling this function.
 }

--- a/sw/device/lib/drivers/dma/dma.c
+++ b/sw/device/lib/drivers/dma/dma.c
@@ -562,7 +562,7 @@ dma_config_flags_t dma_validate_transaction(    dma_trans_t        *p_trans,
          * No further operations are done to prevent corrupting information
          * that could be useful for debugging purposes.
          */
-        uint8_t isEnv = p_trans->dst->env;
+        uint8_t isEnv = (uint8_t)p_trans->dst->env;
         uint8_t isOutb = is_region_outbound(
                                     p_trans->dst->ptr,
                                     p_trans->dst->env->end,
@@ -689,7 +689,7 @@ dma_config_flags_t dma_load_transaction( dma_trans_t *p_trans )
     /*
      * SET THE POINTERS
      */
-    dma_cb.peri->SRC_PTR = dma_cb.trans->src->ptr;
+    dma_cb.peri->SRC_PTR = (uint32_t)dma_cb.trans->src->ptr;
 
     if(dma_cb.trans->mode != DMA_TRANS_MODE_ADDRESS)
     {
@@ -698,11 +698,11 @@ dma_config_flags_t dma_load_transaction( dma_trans_t *p_trans )
         otherwise the destination address is read in a separate port in parallel with the data
         from the address port
         */
-        dma_cb.peri->DST_PTR = dma_cb.trans->dst->ptr;
+        dma_cb.peri->DST_PTR = (uint32_t)dma_cb.trans->dst->ptr;
     }
     else
     {
-        dma_cb.peri->ADDR_PTR = dma_cb.trans->src_addr->ptr;
+        dma_cb.peri->ADDR_PTR = (uint32_t)dma_cb.trans->src_addr->ptr;
     }
 
     /*
@@ -1093,7 +1093,7 @@ static inline uint8_t is_region_outbound(   uint8_t  *p_start,
    */
     uint32_t affectedUnits      = ( p_size_du - 1 ) * p_inc_du + 1;
     uint32_t rangeSize          = DMA_DATA_TYPE_2_SIZE(p_type) * affectedUnits;
-    uint32_t lasByteInsideRange = p_start + rangeSize -1;
+    uint32_t lasByteInsideRange = (uint32_t)(p_start + rangeSize -1);
     return ( p_end < lasByteInsideRange );
     // Size is be guaranteed to be non-zero before calling this function.
 }

--- a/sw/device/lib/drivers/gpio/gpio.c
+++ b/sw/device/lib/drivers/gpio/gpio.c
@@ -150,7 +150,7 @@ gpio_result_t gpio_assign_irq_handler( uint32_t intr_id,
 {
   if( intr_id >= GPIO_INTR_START && intr_id <= GPIO_INTR_END )
   {
-    gpio_handlers[ intr_id - GPIO_INTR_START ] = handler;
+    gpio_handlers[ intr_id - GPIO_INTR_START ] = (void (*)(void))handler;
     return GpioOk;
   }
   return GpioError;
@@ -160,7 +160,7 @@ void gpio_reset_handlers_list( )
 {
     for( uint8_t i = 0; i < GPIO_INTR_QTY; i++ )
     {
-        gpio_handlers[ i ] = &gpio_handler_irq_dummy;
+        gpio_handlers[ i ] = (void (*)(void))&gpio_handler_irq_dummy;
     }
 }
 

--- a/sw/device/lib/drivers/gpio/gpio.c
+++ b/sw/device/lib/drivers/gpio/gpio.c
@@ -129,7 +129,7 @@ void (*gpio_handlers[ GPIO_INTR_QTY ])( void );
 
 volatile gpio * gpio_perif;
 
-__attribute__((optimize("O0"))) static void gpio_handler_irq_dummy( uint32_t dummy );
+__attribute__((optimize("O0"))) static void gpio_handler_irq_dummy( void );
 
 
 __attribute__((always_inline)) void select_gpio_domain(gpio_pin_number_t pin)
@@ -150,7 +150,7 @@ gpio_result_t gpio_assign_irq_handler( uint32_t intr_id,
 {
   if( intr_id >= GPIO_INTR_START && intr_id <= GPIO_INTR_END )
   {
-    gpio_handlers[ intr_id - GPIO_INTR_START ] = handler;
+    gpio_handlers[ intr_id - GPIO_INTR_START ] = (void *)handler;
     return GpioOk;
   }
   return GpioError;
@@ -563,7 +563,7 @@ void gpio_intr_set_mode (gpio_pin_number_t pin, gpio_intr_general_mode_t mode)
 /**                                                                        **/
 /****************************************************************************/
 
-__attribute__((optimize("O0"))) static void gpio_handler_irq_dummy( uint32_t dummy )
+__attribute__((optimize("O0"))) static void gpio_handler_irq_dummy( void )
 {
   return;
 }

--- a/sw/device/lib/drivers/rv_plic/rv_plic.c
+++ b/sw/device/lib/drivers/rv_plic/rv_plic.c
@@ -371,7 +371,7 @@ plic_result_t plic_assign_external_irq_handler( uint32_t id,
 {
   if( id >= EXT_IRQ_START && id <= QTY_INTR )
   {
-    handlers[ id ] = (handler_funct_t*) handler;
+    handlers[ id ] = (handler_funct_t) handler;
     return kPlicOk;
   }
   return kPlicBadArg;

--- a/sw/device/lib/runtime/handler.c
+++ b/sw/device/lib/runtime/handler.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdio.h>
+
 #include "handler.h"
 
 #include "csr.h"

--- a/sw/device/lib/runtime/handler.c
+++ b/sw/device/lib/runtime/handler.c
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
-
 #include "handler.h"
-
 #include "csr.h"
 #include "stdasm.h"
 #include <stdio.h>'

--- a/sw/device/lib/runtime/handler.c
+++ b/sw/device/lib/runtime/handler.c
@@ -6,6 +6,7 @@
 
 #include "csr.h"
 #include "stdasm.h"
+#include <stdio.h>'
 
 /**
  * Return value of mtval

--- a/sw/device/lib/runtime/syscalls.c
+++ b/sw/device/lib/runtime/syscalls.c
@@ -28,10 +28,7 @@
 #include "core_v_mini_mcu.h"
 #include "error.h"
 #include "x-heep.h"
-#include <string.h>
 #include <stdio.h>
-
-ssize_t _write();
 
 #undef errno
 extern int errno;

--- a/sw/device/lib/runtime/syscalls.c
+++ b/sw/device/lib/runtime/syscalls.c
@@ -18,6 +18,7 @@
  */
 
 #include <sys/stat.h>
+#include <string.h>
 #include <newlib.h>
 #include <unistd.h>
 #include <errno.h>
@@ -26,6 +27,8 @@
 #include "core_v_mini_mcu.h"
 #include "error.h"
 #include "x-heep.h"
+
+ssize_t _write();
 
 #undef errno
 extern int errno;

--- a/sw/device/lib/runtime/syscalls.c
+++ b/sw/device/lib/runtime/syscalls.c
@@ -20,30 +20,37 @@
 #include <sys/stat.h>
 #include <newlib.h>
 #include <unistd.h>
+#include <reent.h>
 #include <errno.h>
 #include "uart.h"
 #include "soc_ctrl.h"
 #include "core_v_mini_mcu.h"
 #include "error.h"
 #include "x-heep.h"
+#include <string.h>
+#include <stdio.h>
 
 #undef errno
 extern int errno;
 
 #define STDOUT_FILENO 1
 
-/* It turns out that older newlib versions use different symbol names which goes
- * against newlib recommendations. Anyway this is fixed in later version.
- */
-#if __NEWLIB__ <= 2 && __NEWLIB_MINOR__ <= 5
-#    define _sbrk sbrk
-#    define _write write
-#    define _close close
-#    define _lseek lseek
-#    define _read read
-#    define _fstat fstat
-#    define _isatty isatty
+#ifndef _LIBC
+/* Provide prototypes for most of the _<systemcall> names that are
+   provided in newlib for some compilers.  */
+int     _close (int __fildes);
+pid_t   _fork (void);
+pid_t   _getpid (void);
+int     _isatty (int __fildes);
+int     _link (const char *__path1, const char *__path2);
+_off_t  _lseek (int __fildes, _off_t __offset, int __whence);
+ssize_t _read (int __fd, void *__buf, size_t __nbyte);
+void *  _sbrk (ptrdiff_t __incr);
+int     _unlink (const char *__path);
+ssize_t _write (int __fd, const void *__buf, size_t __nbyte);
+int     _execve (const char *__path, char * const __argv[], char * const __envp[]);
 #endif
+
 
 void unimplemented_syscall()
 {
@@ -108,7 +115,7 @@ int _faccessat(int dirfd, const char *file, int mode, int flags)
     return -1;
 }
 
-int _fork(void)
+pid_t _fork(void)
 {
     errno = EAGAIN;
     return -1;
@@ -140,7 +147,7 @@ char *_getcwd(char *buf, size_t size)
     return NULL;
 }
 
-int _getpid()
+pid_t _getpid()
 {
     return 1;
 }


### PR DESCRIPTION
- Updates to cope with new GCC 14.0 based toolchain (Embecosm 20240114).
- Vendorization of FPnew with hash changed to v0.8.1 release.
- Vendorization of CV32E40P with hash changed to 2024-02-28 version (PR #952).
- 1p0 not needed anymore in march for PULP.
- Added coremark benchmark and improved CMake file to use correct compiler options.
- Added Embench benchmark minver test.